### PR TITLE
Implement Function interface on all spec Param types

### DIFF
--- a/beast-base/src/main/java/beast/base/spec/inference/parameter/BoolScalarParam.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/parameter/BoolScalarParam.java
@@ -26,6 +26,7 @@ package beast.base.spec.inference.parameter;
 
 
 import beast.base.core.Description;
+import beast.base.core.Function;
 import beast.base.core.Input;
 import beast.base.inference.StateNode;
 import beast.base.spec.domain.Bool;
@@ -42,7 +43,7 @@ import java.io.PrintStream;
  */
 @Description("A Boolean-valued parameter represents a value (or array of values if the dimension is larger than one) " +
         "in the state space that can be changed by operators.")
-public class BoolScalarParam extends StateNode implements BoolScalar {
+public class BoolScalarParam extends StateNode implements BoolScalar, Function {
 
     final public Input<Boolean> valuesInput = new Input<>("value",
             "starting value for this real scalar parameter.",
@@ -196,6 +197,18 @@ public class BoolScalarParam extends StateNode implements BoolScalar {
     @Override
     public String toString() {
         return ParameterUtils.paramToString(this);
+    }
+
+    // Function implementation
+
+    @Override
+    public int getDimension() {
+        return 1;
+    }
+
+    @Override
+    public double getArrayValue(int i) {
+        return get() ? 1.0 : 0.0;
     }
 
 }

--- a/beast-base/src/main/java/beast/base/spec/inference/parameter/BoolVectorParam.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/parameter/BoolVectorParam.java
@@ -1,6 +1,7 @@
 package beast.base.spec.inference.parameter;
 
 import beast.base.core.Description;
+import beast.base.core.Function;
 import beast.base.core.Input;
 import beast.base.inference.StateNode;
 import beast.base.spec.domain.Bool;
@@ -20,7 +21,7 @@ import java.util.List;
  * Supports named dimensions via {@link KeyVectorParam}.
  */
 @Description("A boolean-valued vector parameter for MCMC inference.")
-public class BoolVectorParam extends KeyVectorParam<Boolean> implements BoolVector{ //VectorParam<Bool, Boolean> {
+public class BoolVectorParam extends KeyVectorParam<Boolean> implements BoolVector, Function {
 
     final public Input<List<Boolean>> valuesInput = new Input<>("value",
             "starting value for this real scalar parameter.",
@@ -388,6 +389,18 @@ public class BoolVectorParam extends KeyVectorParam<Boolean> implements BoolVect
         for (int i = 0; i < valuesStr.length; i++) {
             values[i] = Boolean.parseBoolean(valuesStr[i]);
         }
+    }
+
+    // Function implementation
+
+    @Override
+    public int getDimension() {
+        return size();
+    }
+
+    @Override
+    public double getArrayValue(int i) {
+        return get(i) ? 1.0 : 0.0;
     }
 
 }

--- a/beast-base/src/main/java/beast/base/spec/inference/parameter/IntScalarParam.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/parameter/IntScalarParam.java
@@ -1,6 +1,7 @@
 package beast.base.spec.inference.parameter;
 
 import beast.base.core.Description;
+import beast.base.core.Function;
 import beast.base.core.Input;
 import beast.base.inference.StateNode;
 import beast.base.spec.domain.Int;
@@ -17,7 +18,7 @@ import java.io.PrintStream;
  * @param <D> the integer domain type
  */
 @Description("A scalar int-valued parameter with domain constraints")
-public class IntScalarParam<D extends Int> extends StateNode implements IntScalar<D> {
+public class IntScalarParam<D extends Int> extends StateNode implements IntScalar<D>, Function {
 
     final public Input<Integer> valuesInput = new Input<>("value",
             "starting value for this real scalar parameter.",
@@ -195,6 +196,18 @@ public class IntScalarParam<D extends Int> extends StateNode implements IntScala
     @Override
     public String toString() {
         return ParameterUtils.paramToString(this);
+    }
+
+    // Function implementation
+
+    @Override
+    public int getDimension() {
+        return 1;
+    }
+
+    @Override
+    public double getArrayValue(int i) {
+        return get();
     }
 
 }

--- a/beast-base/src/main/java/beast/base/spec/inference/parameter/IntVectorParam.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/parameter/IntVectorParam.java
@@ -1,6 +1,7 @@
 package beast.base.spec.inference.parameter;
 
 import beast.base.core.Description;
+import beast.base.core.Function;
 import beast.base.core.Input;
 import beast.base.inference.StateNode;
 import beast.base.spec.domain.Domain;
@@ -25,7 +26,7 @@ import java.util.stream.IntStream;
  * @param <D> the integer domain type
  */
 @Description("A int-valued vector with domain constraints")
-public class IntVectorParam<D extends Int> extends KeyVectorParam<Integer> implements IntVector<D> { //VectorParam<D, Integer> {
+public class IntVectorParam<D extends Int> extends KeyVectorParam<Integer> implements IntVector<D>, Function {
 
     final public Input<List<Integer>> valuesInput = new Input<>("value",
             "starting value for this real scalar parameter.",
@@ -500,4 +501,17 @@ public class IntVectorParam<D extends Int> extends KeyVectorParam<Integer> imple
             values[i] = Integer.parseInt(valuesStr[i]);
         }
     }
+
+    // Function implementation
+
+    @Override
+    public int getDimension() {
+        return size();
+    }
+
+    @Override
+    public double getArrayValue(int i) {
+        return get(i);
+    }
+
 }

--- a/beast-base/src/main/java/beast/base/spec/inference/parameter/RealScalarParam.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/parameter/RealScalarParam.java
@@ -1,6 +1,7 @@
 package beast.base.spec.inference.parameter;
 
 import beast.base.core.Description;
+import beast.base.core.Function;
 import beast.base.core.Input;
 import beast.base.inference.Scalable;
 import beast.base.inference.StateNode;
@@ -19,7 +20,7 @@ import java.io.PrintStream;
  * @param <D> the real domain type
  */
 @Description("A scalar real-valued parameter with domain constraints")
-public class RealScalarParam<D extends Real> extends StateNode implements RealScalar<D>, Scalable {
+public class RealScalarParam<D extends Real> extends StateNode implements RealScalar<D>, Scalable, Function {
 
     final public Input<Double> valuesInput = new Input<>("value",
             "starting value for this real scalar parameter.",
@@ -223,6 +224,18 @@ public class RealScalarParam<D extends Real> extends StateNode implements RealSc
     @Override
     public String toString() {
         return ParameterUtils.paramToString(this);
+    }
+
+    // Function implementation
+
+    @Override
+    public int getDimension() {
+        return 1;
+    }
+
+    @Override
+    public double getArrayValue(int i) {
+        return get();
     }
 
 }

--- a/beast-base/src/main/java/beast/base/spec/inference/parameter/RealVectorParam.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/parameter/RealVectorParam.java
@@ -1,6 +1,7 @@
 package beast.base.spec.inference.parameter;
 
 import beast.base.core.Description;
+import beast.base.core.Function;
 import beast.base.core.Input;
 import beast.base.inference.Scalable;
 import beast.base.inference.StateNode;
@@ -25,7 +26,7 @@ import java.util.stream.DoubleStream;
  * @param <D> the real domain type
  */
 @Description("A real-valued vector with domain constraints")
-public class RealVectorParam<D extends Real> extends KeyVectorParam<Double> implements RealVector<D>, Scalable { //VectorParam<D, Double> {
+public class RealVectorParam<D extends Real> extends KeyVectorParam<Double> implements RealVector<D>, Scalable, Function {
 
     final public Input<List<Double>> valuesInput = new Input<>("value",
             "starting value for this real scalar parameter.",
@@ -529,6 +530,19 @@ public class RealVectorParam<D extends Real> extends KeyVectorParam<Double> impl
         for (int i = 0; i < values.length; i++) {
             values[i] = Double.parseDouble(valuesStr[i]);
         }
+    }
+
+    // Function implementation -- bridges spec types to legacy Function interface
+    // used by loggers, metadata, and other infrastructure
+
+    @Override
+    public int getDimension() {
+        return size();
+    }
+
+    @Override
+    public double getArrayValue(int i) {
+        return get(i);
     }
 
 }


### PR DESCRIPTION
## Summary

- All six spec parameter types now implement the `Function` interface: `RealVectorParam`, `RealScalarParam`, `IntVectorParam`, `IntScalarParam`, `BoolVectorParam`, `BoolScalarParam`
- This bridges the spec type system to legacy beast3 infrastructure that accepts `Input<Function>` (loggers, `TreeWithMetaDataLogger`, distribution M/S parameters, `RPNcalculator`, etc.)
- Enables package migrations (e.g. beast-classic) to use spec param types without losing compatibility with `Function`-based inputs

The implementations delegate to existing spec methods:
- `getDimension()` delegates to `size()` (or returns 1 for scalars)
- `getArrayValue(i)` delegates to `get(i)` (or `get()` for scalars)
- Bool types return `1.0`/`0.0` for `true`/`false`

## Motivation

During the beast-classic strong typing migration, we hit a wall: XML files that reference a parameter from both a spec-typed input (e.g. `Input<RealVectorParam>`) and a `Function`-typed input (e.g. `TreeWithMetaDataLogger.metadata`) cannot work with a single parameter object, because `RealVectorParam` is not a `Function`. This affects every package migration, not just beast-classic.

Since `Function` is a read-only numeric interface and the spec Param types already have equivalent methods (`size()`, `get()`), implementing `Function` is just adding method aliases. It does not compromise the strong typing goals of the spec hierarchy.

## Test plan

- [x] All 382 beast-base tests pass
- [x] Full beast3 compiles (beast-base + beast-fx)