### PR TITLE
Fix BEASTClassLoader dual-loader class identity split

### DIFF
--- a/beast-pkgmgmt/src/main/java/beast/pkgmgmt/BEASTClassLoader.java
+++ b/beast-pkgmgmt/src/main/java/beast/pkgmgmt/BEASTClassLoader.java
@@ -345,7 +345,6 @@ public class BEASTClassLoader {
 
     /** Instance method: register services for a package. */
     public void addServices(String packageName, Map<String, Set<String>> services) {
-        ClassLoader loader = fallbackClassLoader();
         for (String service : services.keySet()) {
             BEASTClassLoader.services.computeIfAbsent(service, k -> new HashSet<>());
             Set<String> providers = BEASTClassLoader.services.get(service);
@@ -354,7 +353,7 @@ public class BEASTClassLoader {
                 // Use putIfAbsent so that a module-layer class-loader
                 // registered by registerPluginLayer() is not overwritten
                 // with the fallback system class-loader.
-                class2loaderMap.putIfAbsent(provider, loader);
+                class2loaderMap.putIfAbsent(provider, resolveLoaderFor(provider));
                 if (provider.contains(".")) {
                     namespaces.add(provider.substring(0, provider.lastIndexOf('.')));
                 }
@@ -367,7 +366,7 @@ public class BEASTClassLoader {
      */
     public static void addService(String service, String className, String packageName) {
         ensureServicesLoaded(service).add(className);
-        class2loaderMap.put(className, fallbackClassLoader());
+        class2loaderMap.put(className, resolveLoaderFor(className));
     }
 
     /**
@@ -536,5 +535,30 @@ public class BEASTClassLoader {
     private static ClassLoader fallbackClassLoader() {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         return cl != null ? cl : ClassLoader.getSystemClassLoader();
+    }
+
+    /**
+     * Resolve the class-loader that should be used to load {@code provider}.
+     * If a named module on the boot layer owns the provider's package, that
+     * module's class-loader is returned. Otherwise we fall back to the
+     * thread context / system class-loader.
+     *
+     * <p>This avoids a class-identity split when the same JAR is reachable
+     * via both the module path and the class path: callers compiled against
+     * the module copy of a class would otherwise hit ClassCastException when
+     * BEASTClassLoader.forName() returned the app-loader copy.
+     */
+    private static ClassLoader resolveLoaderFor(String provider) {
+        int dot = provider.lastIndexOf('.');
+        if (dot < 0) return fallbackClassLoader();
+        String pkg = provider.substring(0, dot);
+        for (Module m : ModuleLayer.boot().modules()) {
+            java.lang.module.ModuleDescriptor desc = m.getDescriptor();
+            if (desc != null && desc.packages().contains(pkg)) {
+                ClassLoader loader = m.getClassLoader();
+                if (loader != null) return loader;
+            }
+        }
+        return fallbackClassLoader();
     }
 }


### PR DESCRIPTION
Fixes #65.

## Summary

- Add `resolveLoaderFor(provider)` to `BEASTClassLoader`: prefer the class-loader of the boot-layer module that owns the provider's package; fall back to the thread-context loader only when no named module claims the package.
- Use it from instance `addServices(String, Map)` and static `addService(String, String, String)` instead of unconditional `fallbackClassLoader()`.

This brings the version.xml registration path in line with the JPMS `provides` registration path (`mergeAllProviders` / `collectProviders`), which already used `m.getClassLoader()` from the providing module.

## Why

When `beast-base` is reachable via both the JPMS module path and the classpath in the same JVM (typical of surefire and IDE runs), the old code stored the app class-loader against every version.xml provider. `BEASTClassLoader.forName()` then returned the app-loader copy of (e.g.) `beast.base.evolution.tree.Node`, while application code resolved through the module-loader copy. The two `Class<?>` instances were incompatible, producing `ClassCastException` and an empty data-type registry. See #65 for the full diagnosis and reproduction.

## Test plan

- [x] `mvn -pl beast-pkgmgmt test` — 40/40 pass with the patch.
- [ ] End-to-end validation against LPhyBeast on a machine that previously hit the failures:
  ```bash
  cd ~/Git/beast3
  git fetch origin
  git checkout fix-classloader-dual-load
  mvn install -DskipTests
  ```
  Then in `LPhyBeast/pom.xml` change `<beast.version>2.8.0-beta4</beast.version>` to `<beast.version>2.8.0-SNAPSHOT</beast.version>` and run `mvn -pl lphybeast test`. The previously-failing `H5N1TutorialTest.testDPG` and the two `LPhyScriptsToBEASTTest` cases should pass.