### PR TITLE
Add LogUniform distribution to beast.base.spec

### DIFF
--- a/beast-base/src/main/java/beast/base/spec/inference/distribution/LogUniform.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/distribution/LogUniform.java
@@ -1,0 +1,190 @@
+package beast.base.spec.inference.distribution;
+
+import beast.base.core.Description;
+import beast.base.core.Input;
+import beast.base.spec.Bounded;
+import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.type.RealScalar;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.statistics.distribution.ContinuousDistribution;
+
+import java.util.List;
+
+/**
+ * Log-uniform (reciprocal) distribution on [lower, upper] with lower > 0.
+ * Equivalent to a uniform distribution on log(x). The density is
+ * p(x) = 1 / (x * log(upper/lower)) on [lower, upper], zero elsewhere.
+ * Commonly used as a scale-invariant proper prior for strictly positive
+ * quantities (population sizes, rates, variances), replacing the improper
+ * OneOnX prior when a finite support is acceptable.
+ */
+@Description("Log-uniform distribution on [lower, upper], lower > 0. " +
+        "Density is 1/(x log(upper/lower)). Equivalent to a uniform distribution " +
+        "on log(x). Provides a proper, scale-invariant prior for strictly positive " +
+        "quantities over many orders of magnitude.")
+public class LogUniform extends ScalarDistribution<RealScalar<PositiveReal>, Double>
+        implements Bounded<Double> {
+
+    final public Input<RealScalar<PositiveReal>> lowerInput = new Input<>("lower",
+            "lower bound of the support, strictly positive. Defaults to 1.");
+    final public Input<RealScalar<PositiveReal>> upperInput = new Input<>("upper",
+            "upper bound of the support, must exceed lower. Defaults to e.");
+
+    private LogUniformImpl dist = new LogUniformImpl(1.0, Math.E);
+    private ContinuousDistribution.Sampler sampler;
+
+    /**
+     * Must provide empty constructor for construction by XML.
+     * Note that this constructor DOES NOT call initAndValidate();
+     */
+    public LogUniform() {}
+
+    public LogUniform(RealScalar<PositiveReal> param,
+                      RealScalar<PositiveReal> lower, RealScalar<PositiveReal> upper) {
+        try {
+            initByName("param", param, "lower", lower, "upper", upper);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to initialize " + getClass().getSimpleName() +
+                    " via initByName in constructor.", e);
+        }
+    }
+
+    @Override
+    public void initAndValidate() {
+        refresh();
+        super.initAndValidate();
+    }
+
+    @Override
+    public void refresh() {
+        double lower = (lowerInput.get() != null) ? lowerInput.get().get() : 1.0;
+        double upper = (upperInput.get() != null) ? upperInput.get().get() : Math.E;
+
+        if (!(lower > 0.0) || !Double.isFinite(upper) || !(upper > lower)) {
+            throw new IllegalArgumentException(
+                    "LogUniform requires 0 < lower < upper < infinity, got [" +
+                            lower + ", " + upper + "]");
+        }
+
+        if (isNotEqual(dist.lower, lower) || isNotEqual(dist.upper, upper)) {
+            dist = new LogUniformImpl(lower, upper);
+            sampler = null;
+        }
+    }
+
+    @Override
+    public double calculateLogP() {
+        logP = getApacheDistribution().logDensity(param.get());
+        return logP;
+    }
+
+    @Override
+    public List<Double> sample() {
+        if (sampler == null) {
+            sampler = dist.createSampler(rng);
+        }
+        final double x = sampler.sample();
+        return List.of(x);
+    }
+
+    @Override
+    protected LogUniformImpl getApacheDistribution() {
+        refresh();
+        return dist;
+    }
+
+    @Override
+    public boolean lowerInclusive() {
+        return true;
+    }
+
+    @Override
+    public boolean upperInclusive() {
+        return true;
+    }
+
+    @Override
+    public Double getLower() {
+        return (lowerInput.get() != null) ? lowerInput.get().get() : 1.0;
+    }
+
+    @Override
+    public Double getUpper() {
+        return (upperInput.get() != null) ? upperInput.get().get() : Math.E;
+    }
+
+    /**
+     * Apache Commons Statistics does not provide a LogUniform/reciprocal
+     * distribution, so implement the interface directly.
+     */
+    static final class LogUniformImpl implements ContinuousDistribution {
+
+        final double lower;
+        final double upper;
+        final double logRange; // log(upper / lower), strictly positive
+
+        LogUniformImpl(double lower, double upper) {
+            this.lower = lower;
+            this.upper = upper;
+            this.logRange = Math.log(upper / lower);
+        }
+
+        @Override
+        public double density(double x) {
+            if (x < lower || x > upper) return 0.0;
+            return 1.0 / (x * logRange);
+        }
+
+        @Override
+        public double logDensity(double x) {
+            if (x < lower || x > upper) return Double.NEGATIVE_INFINITY;
+            return -Math.log(x) - Math.log(logRange);
+        }
+
+        @Override
+        public double cumulativeProbability(double x) {
+            if (x <= lower) return 0.0;
+            if (x >= upper) return 1.0;
+            return Math.log(x / lower) / logRange;
+        }
+
+        @Override
+        public double inverseCumulativeProbability(double p) {
+            if (p < 0.0 || p > 1.0) {
+                throw new IllegalArgumentException("p must be in [0,1], got " + p);
+            }
+            if (p == 0.0) return lower;
+            if (p == 1.0) return upper;
+            return lower * Math.exp(p * logRange);
+        }
+
+        @Override
+        public double getMean() {
+            // E[X] = (upper - lower) / log(upper/lower)
+            return (upper - lower) / logRange;
+        }
+
+        @Override
+        public double getVariance() {
+            // E[X^2] = (upper^2 - lower^2) / (2 log(upper/lower))
+            double ex2 = (upper * upper - lower * lower) / (2.0 * logRange);
+            double mean = getMean();
+            return ex2 - mean * mean;
+        }
+
+        @Override
+        public double getSupportLowerBound() {
+            return lower;
+        }
+
+        @Override
+        public double getSupportUpperBound() {
+            return upper;
+        }
+
+        @Override
+        public Sampler createSampler(UniformRandomProvider rng) {
+            return () -> inverseCumulativeProbability(rng.nextDouble());
+        }
+    }
+}

--- a/beast-base/src/main/java/module-info.java
+++ b/beast-base/src/main/java/module-info.java
@@ -270,6 +270,7 @@ open module beast.base {
         beast.base.spec.inference.distribution.InverseGamma,
         beast.base.spec.inference.distribution.Laplace,
         beast.base.spec.inference.distribution.LogNormal,
+        beast.base.spec.inference.distribution.LogUniform,
         beast.base.spec.inference.distribution.MarkovChainDistribution,
         beast.base.spec.inference.distribution.Normal,
         beast.base.spec.inference.distribution.Poisson,

--- a/beast-base/src/test/java/beast/base/spec/inference/distribution/LogUniformTest.java
+++ b/beast-base/src/test/java/beast/base/spec/inference/distribution/LogUniformTest.java
@@ -1,0 +1,108 @@
+package beast.base.spec.inference.distribution;
+
+import beast.base.parser.XMLParser;
+import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.inference.parameter.RealScalarParam;
+import beast.base.util.Randomizer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LogUniformTest {
+
+    private LogUniform newLogUniform(double lower, double upper) {
+        LogUniform d = new LogUniform();
+        d.initByName(
+                "lower", new RealScalarParam<>(lower, PositiveReal.INSTANCE),
+                "upper", new RealScalarParam<>(upper, PositiveReal.INSTANCE));
+        return d;
+    }
+
+    @BeforeEach
+    public void setUp() {
+        Randomizer.setSeed(42);
+    }
+
+    @Test
+    public void testLogDensityAgainstClosedForm() {
+        LogUniform d = newLogUniform(1.0e-3, 1.0e3);
+        double logRange = Math.log(1.0e3 / 1.0e-3); // = 6 log 10
+        for (double x : new double[]{1.0e-2, 1.0, 50.0, 500.0}) {
+            double expected = -Math.log(x) - Math.log(logRange);
+            assertEquals(expected, d.logDensity(x), 1e-12);
+            assertEquals(Math.exp(expected), d.density(x), 1e-12);
+        }
+    }
+
+    @Test
+    public void testDensityZeroOutsideSupport() {
+        LogUniform d = newLogUniform(1.0, 10.0);
+        assertEquals(0.0, d.density(0.5), 0.0);
+        assertEquals(0.0, d.density(11.0), 0.0);
+        assertEquals(Double.NEGATIVE_INFINITY, d.logDensity(0.5), 0.0);
+    }
+
+    @Test
+    public void testCDFAndInverseRoundTrip() {
+        LogUniform d = newLogUniform(1.0e-6, 1.0e6);
+        for (int i = 0; i < 1000; i++) {
+            double p = Randomizer.nextDouble();
+            double x = d.inverseCumulativeProbability(p);
+            assertTrue(x >= 1.0e-6 && x <= 1.0e6);
+            assertEquals(p, d.cumulativeProbability(x), 1e-12);
+        }
+    }
+
+    @Test
+    public void testSupportIsUniformInLogSpace() {
+        // Median of LogUniform[a,b] is sqrt(a*b)
+        LogUniform d = newLogUniform(1.0, 100.0);
+        assertEquals(10.0, d.inverseCumulativeProbability(0.5), 1e-12);
+    }
+
+    @Test
+    public void testMean() {
+        // E[X] = (b-a) / log(b/a)
+        LogUniform d = newLogUniform(1.0, Math.E);
+        assertEquals(Math.E - 1.0, d.getMean(), 1e-12);
+    }
+
+    @Test
+    public void testCalcLogPViaParam() {
+        LogUniform d = new LogUniform();
+        d.initByName(
+                "param", new RealScalarParam<>(10.0, PositiveReal.INSTANCE),
+                "lower", new RealScalarParam<>(1.0, PositiveReal.INSTANCE),
+                "upper", new RealScalarParam<>(100.0, PositiveReal.INSTANCE));
+        double expected = -Math.log(10.0) - Math.log(Math.log(100.0));
+        assertEquals(expected, d.calculateLogP(), 1e-12);
+    }
+
+    @Test
+    public void testXMLConstruction() throws Exception {
+        final String xml = "<distribution spec='beast.base.spec.inference.distribution.LogUniform'>\n" +
+                "  <lower spec='beast.base.spec.inference.parameter.RealScalarParam' " +
+                "         domain='PositiveReal' value='0.001'/>\n" +
+                "  <upper spec='beast.base.spec.inference.parameter.RealScalarParam' " +
+                "         domain='PositiveReal' value='1000'/>\n" +
+                "</distribution>\n";
+        XMLParser parser = new XMLParser();
+        LogUniform d = (LogUniform) parser.parseBareFragment(xml, true);
+        double expected = -Math.log(1.0) - Math.log(Math.log(1.0e6));
+        assertEquals(expected, d.logDensity(1.0), 1e-12);
+    }
+
+    @Test
+    public void testRejectsDegenerateBounds() {
+        // PositiveReal blocks lower <= 0 at parameter construction; distribution must
+        // also reject equal and inverted bounds. initAndValidate wraps our IAE into a
+        // bare RuntimeException with no cause, so we match on the message.
+        RuntimeException e1 = assertThrows(RuntimeException.class, () -> newLogUniform(5.0, 5.0));
+        assertTrue(e1.getMessage().contains("LogUniform requires"), "unexpected: " + e1.getMessage());
+        RuntimeException e2 = assertThrows(RuntimeException.class, () -> newLogUniform(10.0, 1.0));
+        assertTrue(e2.getMessage().contains("LogUniform requires"), "unexpected: " + e2.getMessage());
+    }
+}

--- a/version.xml
+++ b/version.xml
@@ -221,6 +221,7 @@
                 <provider classname="beast.base.spec.inference.distribution.InverseGamma"/>
                 <provider classname="beast.base.spec.inference.distribution.Laplace"/>
                 <provider classname="beast.base.spec.inference.distribution.LogNormal"/>
+                <provider classname="beast.base.spec.inference.distribution.LogUniform"/>
                 <provider classname="beast.base.spec.inference.distribution.MarkovChainDistribution"/>
                 <provider classname="beast.base.spec.inference.distribution.Normal"/>
 <!--OneOnX not migrated, it is not a distribution-->


### PR DESCRIPTION
## Summary

Adds `LogUniform` as a proper, scale-invariant `ScalarDistribution` for strictly positive quantities — the defensible replacement for the improper `OneOnX` prior, which was deliberately not migrated to the spec types (see existing note in `version.xml:226`).

- Density `p(x) = 1 / (x * log(upper/lower))` on `[lower, upper]`, equivalent to `Uniform` on `log(x)`.
- Apache Commons Statistics has no reciprocal distribution, so `ContinuousDistribution` is implemented inline with closed-form density, CDF, inverse CDF, mean, variance, and inverse-CDF sampler.
- Parameters `lower`, `upper` are `RealScalar<PositiveReal>`; the distribution validates `0 < lower < upper < infinity` in `refresh()`.
- Registered as a `BEASTInterface` service provider in both `module-info.java` and `version.xml`.

## Motivation

FLC's beast3 migration (4ment/flc#10) uses `OneOnX` on the coalescent `popSize`; that block is currently commented out because `OneOnX` has no spec-type counterpart. `LogUniform` on e.g. `[1e-6, 1e6]` gives twelve orders of magnitude of scale-invariant prior support — behaviourally equivalent for typical molecular-clock analyses, philosophically cleaner (proper, integrable, has a CDF and quantile), and usable anywhere `ScalarDistribution` is expected.

## Test plan

- [x] `LogUniformTest` (8 tests): closed-form density, zero outside support, CDF/quantile round-trip (1000 random pairs), log-space median equals sqrt(ab), mean formula, `calculateLogP` via param, XML parse, rejection of degenerate bounds
- [x] Full `beast-base` suite: 399 tests, 0 failures, 0 errors
- [ ] Verify downstream: use `LogUniform` for `popSize` prior in FLC example XML
