### PR TITLE
Make operator target acceptance probability configurable; bump 1-D defaults to 0.3

### DIFF
--- a/beast-base/src/main/java/beast/base/evolution/operator/EpochFlexOperator.java
+++ b/beast-base/src/main/java/beast/base/evolution/operator/EpochFlexOperator.java
@@ -180,7 +180,7 @@ public class EpochFlexOperator extends Operator {
     }
     
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
     	return 0.4;
     }
     

--- a/beast-base/src/main/java/beast/base/evolution/operator/ScaleOperator.java
+++ b/beast-base/src/main/java/beast/base/evolution/operator/ScaleOperator.java
@@ -297,6 +297,11 @@ public class ScaleOperator extends Operator {
     }
 
     @Override
+    public double getDefaultTargetAcceptanceProbability() {
+        return 0.3;
+    }
+
+    @Override
     public String getPerformanceSuggestion() {
         final double prob = m_nNrAccepted / (m_nNrAccepted + m_nNrRejected + 0.0);
         final double targetProb = getTargetAcceptanceProbability();

--- a/beast-base/src/main/java/beast/base/evolution/operator/SubtreeSlide.java
+++ b/beast-base/src/main/java/beast/base/evolution/operator/SubtreeSlide.java
@@ -292,6 +292,11 @@ public class SubtreeSlide extends TreeOperator {
     }
 
     @Override
+    public double getDefaultTargetAcceptanceProbability() {
+        return 0.3;
+    }
+
+    @Override
     public String getPerformanceSuggestion() {
         final double prob = m_nNrAccepted / (m_nNrAccepted + m_nNrRejected + 0.0);
         final double targetProb = getTargetAcceptanceProbability();

--- a/beast-base/src/main/java/beast/base/evolution/operator/TipDatesRandomWalker.java
+++ b/beast-base/src/main/java/beast/base/evolution/operator/TipDatesRandomWalker.java
@@ -170,6 +170,11 @@ public class TipDatesRandomWalker extends TreeOperator {
     }
 
     @Override
+    public double getDefaultTargetAcceptanceProbability() {
+        return 0.3;
+    }
+
+    @Override
     public void optimize(double logAlpha) {
         // must be overridden by operator implementation to have an effect
         double delta = calcDelta(logAlpha);

--- a/beast-base/src/main/java/beast/base/evolution/operator/TipDatesScaler.java
+++ b/beast-base/src/main/java/beast/base/evolution/operator/TipDatesScaler.java
@@ -96,6 +96,11 @@ public class TipDatesScaler extends TreeOperator {
         scaleFactor = value;
     }
 
+    @Override
+    public double getDefaultTargetAcceptanceProbability() {
+        return 0.3;
+    }
+
 
     @Override
     public void optimize(double logAlpha) {

--- a/beast-base/src/main/java/beast/base/evolution/operator/kernel/AdaptableVarianceMultivariateNormalOperator.java
+++ b/beast-base/src/main/java/beast/base/evolution/operator/kernel/AdaptableVarianceMultivariateNormalOperator.java
@@ -840,7 +840,7 @@ public class AdaptableVarianceMultivariateNormalOperator extends KernelOperator 
     }
     
     @Override
-    public final double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
         return DEFAULT_ADAPTATION_TARGET;
     }
 

--- a/beast-base/src/main/java/beast/base/evolution/operator/kernel/BactrianNodeOperator.java
+++ b/beast-base/src/main/java/beast/base/evolution/operator/kernel/BactrianNodeOperator.java
@@ -116,7 +116,7 @@ public class BactrianNodeOperator extends TreeOperator {
     }
     
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
     	return 0.3;
     }
     

--- a/beast-base/src/main/java/beast/base/evolution/operator/kernel/BactrianScaleOperator.java
+++ b/beast-base/src/main/java/beast/base/evolution/operator/kernel/BactrianScaleOperator.java
@@ -209,7 +209,7 @@ public class BactrianScaleOperator extends ScaleOperator {
     }
     
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
     	return 0.3;
     }
     

--- a/beast-base/src/main/java/beast/base/evolution/operator/kernel/BactrianSubtreeSlide.java
+++ b/beast-base/src/main/java/beast/base/evolution/operator/kernel/BactrianSubtreeSlide.java
@@ -283,6 +283,11 @@ public class BactrianSubtreeSlide extends TreeOperator {
     }
 
     @Override
+    public double getDefaultTargetAcceptanceProbability() {
+        return 0.3;
+    }
+
+    @Override
     public String getPerformanceSuggestion() {
         final double prob = m_nNrAccepted / (m_nNrAccepted + m_nNrRejected + 0.0);
         final double targetProb = getTargetAcceptanceProbability();

--- a/beast-base/src/main/java/beast/base/inference/Operator.java
+++ b/beast-base/src/main/java/beast/base/inference/Operator.java
@@ -44,6 +44,10 @@ import beast.base.core.Input.Validate;
 public abstract class Operator extends BEASTObject {
     final public Input<Double> m_pWeight = new Input<>("weight", "weight with which this operator is selected", Validate.REQUIRED);
 
+    final public Input<Double> targetAcceptanceProbabilityInput = new Input<>("targetAcceptanceProbability",
+            "target acceptance probability for auto-tuning. If unset (NaN), uses the operator's default.",
+            Double.NaN);
+
     private final String STANDARD_OPERATOR_PACKAGE = "beast.base.evolution.operator";
 
     /**
@@ -158,9 +162,25 @@ public abstract class Operator extends BEASTObject {
     } // calcDelta
 
     /**
-     * @return target for automatic operator optimisation
+     * @return target for automatic operator optimisation. Resolves the
+     *         {@code targetAcceptanceProbability} XML input if set; otherwise
+     *         falls back to {@link #getDefaultTargetAcceptanceProbability()}.
+     *         Subclasses should override {@code getDefaultTargetAcceptanceProbability}
+     *         to set an operator-specific default.
      */
     public double getTargetAcceptanceProbability() {
+        Double v = targetAcceptanceProbabilityInput.get();
+        if (v == null || Double.isNaN(v)) {
+            return getDefaultTargetAcceptanceProbability();
+        }
+        return v;
+    }
+
+    /**
+     * @return operator-specific default target acceptance probability. Override
+     *         in subclasses to set the default for a particular operator.
+     */
+    public double getDefaultTargetAcceptanceProbability() {
         return 0.234;
     }
 

--- a/beast-base/src/main/java/beast/base/inference/operator/DeltaExchangeOperator.java
+++ b/beast-base/src/main/java/beast/base/inference/operator/DeltaExchangeOperator.java
@@ -352,6 +352,11 @@ public class DeltaExchangeOperator extends Operator {
         delta = value;
     }
 
+    @Override
+    public double getDefaultTargetAcceptanceProbability() {
+        return 0.3;
+    }
+
     /**
      * called after every invocation of this operator to see whether
      * a parameter can be optimised for better acceptance hence faster

--- a/beast-base/src/main/java/beast/base/inference/operator/RealRandomWalkOperator.java
+++ b/beast-base/src/main/java/beast/base/inference/operator/RealRandomWalkOperator.java
@@ -78,6 +78,11 @@ public class RealRandomWalkOperator extends Operator {
         windowSize = value;
     }
 
+    @Override
+    public double getDefaultTargetAcceptanceProbability() {
+        return 0.3;
+    }
+
     /**
      * called after every invocation of this operator to see whether
      * a parameter can be optimised for better acceptance hence faster

--- a/beast-base/src/main/java/beast/base/inference/operator/kernel/BactrianDeltaExchangeOperator.java
+++ b/beast-base/src/main/java/beast/base/inference/operator/kernel/BactrianDeltaExchangeOperator.java
@@ -402,7 +402,7 @@ public class BactrianDeltaExchangeOperator extends KernelOperator {
     
 	
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
     	return 0.3;
     }
 

--- a/beast-base/src/main/java/beast/base/inference/operator/kernel/BactrianIntervalOperator.java
+++ b/beast-base/src/main/java/beast/base/inference/operator/kernel/BactrianIntervalOperator.java
@@ -105,7 +105,7 @@ public class BactrianIntervalOperator extends KernelOperator {
     }
     
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
     	return 0.3;
     }
     

--- a/beast-base/src/main/java/beast/base/inference/operator/kernel/BactrianRandomWalkOperator.java
+++ b/beast-base/src/main/java/beast/base/inference/operator/kernel/BactrianRandomWalkOperator.java
@@ -89,7 +89,7 @@ public class BactrianRandomWalkOperator extends KernelOperator {
     }
 
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
     	return 0.3;
     }
 

--- a/beast-base/src/main/java/beast/base/inference/operator/kernel/BactrianUpDownOperator.java
+++ b/beast-base/src/main/java/beast/base/inference/operator/kernel/BactrianUpDownOperator.java
@@ -186,11 +186,6 @@ public class BactrianUpDownOperator extends KernelOperator {
     }
 
     @Override
-    public double getTargetAcceptanceProbability() {
-    	return 0.3;
-    }
-
-    @Override
     public String getPerformanceSuggestion() {
         double prob = m_nNrAccepted / (m_nNrAccepted + m_nNrRejected + 0.0);
         double targetProb = getTargetAcceptanceProbability();

--- a/beast-base/src/main/java/beast/base/spec/evolution/operator/AdaptableVarianceMultivariateNormalOperator.java
+++ b/beast-base/src/main/java/beast/base/spec/evolution/operator/AdaptableVarianceMultivariateNormalOperator.java
@@ -876,7 +876,7 @@ public class AdaptableVarianceMultivariateNormalOperator extends KernelOperator 
     }
     
     @Override
-    public final double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
         return DEFAULT_ADAPTATION_TARGET;
     }
 

--- a/beast-base/src/main/java/beast/base/spec/evolution/operator/IntervalScaleOperator.java
+++ b/beast-base/src/main/java/beast/base/spec/evolution/operator/IntervalScaleOperator.java
@@ -144,7 +144,7 @@ public class IntervalScaleOperator extends TreeOperator {
     }
     
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
     	return 0.3;
     }
     

--- a/beast-base/src/main/java/beast/base/spec/evolution/operator/UpDownOperator.java
+++ b/beast-base/src/main/java/beast/base/spec/evolution/operator/UpDownOperator.java
@@ -289,11 +289,6 @@ public class UpDownOperator extends KernelOperator {
     }
 
     @Override
-    public double getTargetAcceptanceProbability() {
-    	return 0.3;
-    }
-
-    @Override
     public String getPerformanceSuggestion() {
         double prob = m_nNrAccepted / (m_nNrAccepted + m_nNrRejected + 0.0);
         double targetProb = getTargetAcceptanceProbability();

--- a/beast-base/src/main/java/beast/base/spec/inference/operator/AbstractScale.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/operator/AbstractScale.java
@@ -111,7 +111,7 @@ public abstract class AbstractScale extends KernelOperator {
      * @return the target acceptance probability
      */
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
         return Target_Acceptance_Probability;
     }
 

--- a/beast-base/src/main/java/beast/base/spec/inference/operator/DeltaExchangeOperator.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/operator/DeltaExchangeOperator.java
@@ -334,7 +334,7 @@ public class DeltaExchangeOperator extends KernelOperator {
     
 	
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
     	return 0.3;
     }
 

--- a/beast-base/src/main/java/beast/base/spec/inference/operator/RealRandomWalkOperator.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/operator/RealRandomWalkOperator.java
@@ -107,7 +107,7 @@ public class RealRandomWalkOperator extends KernelOperator {
     }
 
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
     	return 0.3;
     }
 

--- a/beast-base/src/main/java/beast/base/spec/inference/operator/uniform/IntervalOperator.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/operator/uniform/IntervalOperator.java
@@ -190,7 +190,7 @@ public class IntervalOperator extends KernelOperator {
     }
 
     @Override
-    public double getTargetAcceptanceProbability() {
+    public double getDefaultTargetAcceptanceProbability() {
         return Target_Acceptance_Probability;
     }
 


### PR DESCRIPTION
## Summary

Adds a `targetAcceptanceProbability` XML input on the `Operator` base class so users can override the auto-tune target per operator without code changes.
Refactors the resolution path (input -> `getDefaultTargetAcceptanceProbability()` -> base default) and migrates every existing override to the new method name.
Adjusts a few defaults at the same time.

## What changes

**Base class** (`Operator.java`):
- New `Input<Double> targetAcceptanceProbabilityInput` (default `Double.NaN`, meaning "use operator default").
- `getTargetAcceptanceProbability()` now returns the input if set, otherwise calls `getDefaultTargetAcceptanceProbability()`.
- New `getDefaultTargetAcceptanceProbability()` returning 0.234, which subclasses override.

**Migrated overrides** (functionally equivalent, just renamed): `BactrianScaleOperator`, `BactrianNodeOperator`, `BactrianRandomWalkOperator`, `BactrianIntervalOperator`, `BactrianDeltaExchangeOperator`, `EpochFlexOperator`, `AdaptableVarianceMultivariateNormalOperator` (legacy and spec, drops `final`), `IntervalScaleOperator` (spec), `AbstractScale` (spec), `RealRandomWalkOperator` (spec), `DeltaExchangeOperator` (spec), `IntervalOperator` (spec).

**Default bumped 0.234 -> 0.3** (1-D operators that were inheriting the base default):
- `SubtreeSlide`, `BactrianSubtreeSlide`
- `ScaleOperator`
- `TipDatesScaler`, `TipDatesRandomWalker` (`BactrianTipDatesRandomWalker` inherits via its parent)
- `RealRandomWalkOperator` (legacy inference)
- `DeltaExchangeOperator` (legacy inference)

**Default reverted 0.3 -> 0.234** (multi-D operators that should use the asymptotic target): `BactrianUpDownOperator`, `UpDownOperator` (spec).
The legacy `inference/operator/UpDownOperator.java` already inherited 0.234 and is unchanged.

Operators with deliberate non-default values are kept (`EpochFlexOperator` 0.4) but renamed to `getDefaultTargetAcceptanceProbability`.

## Why

The 0.234 default comes from Roberts, Gelman, Gilks (1997) and is the asymptotic optimum for random-walk Metropolis as dimension increases.
For 1-D moves the optimum is closer to 0.44 (Gelman, Roberts, Gilks 1996; Roberts and Rosenthal 2001), so 0.234 is too low.

We observed this in practice on a real-data analysis: starting `BactrianSubtreeSlide` at `size=0.002` with `optimise="false"` gave ~53% acceptance, but with `optimise="true"` the auto-tuner repeatedly increased step size to drive acceptance toward 0.234, and after enough moves the 1/n Robbins-Monro gain became too small to walk the size back when steady-state acceptance fell to ~5%.
A target of 0.3 is a conservative compromise that does not require the tuner to push as hard against the structural acceptance ceiling of these 1-D operators.

The XML input lets users override on a case-by-case basis without further code changes:

```xml
<operator id="treeSlide" spec="...BactrianSubtreeSlide" tree="@psi" weight="9.25"
          targetAcceptanceProbability="0.4"/>
```

## Test plan

- [x] `mvn -pl beast-base -am compile` clean
- [x] `mvn compile` (all modules) clean
- [x] `mvn -pl beast-base test -Dtest='*Operator*Test'` -> 20/20 pass
- [ ] Reviewer to confirm no XML schema/template assumes the absence of this input
- [ ] Re-run the affected XML with the new defaults and confirm `BactrianSubtreeSlide` auto-tunes to a sensible step size