### PR TITLE
Fix OffsetReal.calculateLogP() double-subtracting offset

### DIFF
--- a/beast-base/src/main/java/beast/base/spec/inference/distribution/OffsetReal.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/distribution/OffsetReal.java
@@ -73,7 +73,7 @@ public class OffsetReal extends ScalarDistribution<RealScalar<Real>, Double> {
 
     @Override
     public double calculateLogP() {
-        logP = logDensity(param.get() - offset.get()); // no unboxing needed, faster
+        logP = logDensity(param.get()); // no unboxing needed, faster
         return logP;
     }
 

--- a/beast-base/src/test/java/beast/base/spec/inference/distribution/MeanOfParametricDistributionTest.java
+++ b/beast-base/src/test/java/beast/base/spec/inference/distribution/MeanOfParametricDistributionTest.java
@@ -189,6 +189,38 @@ public class MeanOfParametricDistributionTest  {
         
 	}
 	
+	@Test
+	public void testCalculateLogPOfOffsetReal() {
+		// Exp(mean=1) has logp(x) = -x for x >= 0.
+		// OffsetReal(Exp(mean=1), offset=3) at param=4 -> underlying x=1, logp=-1.
+		Exponential exp1 = new Exponential(null, new RealScalarParam<>(1, PositiveReal.INSTANCE));
+		OffsetReal off = new OffsetReal();
+		off.initByName(
+				"distribution", exp1,
+				"offset", new RealScalarParam<>(3.0, Real.INSTANCE),
+				"param", new RealScalarParam<>(4.0, Real.INSTANCE));
+		assertEquals(-1.0, off.calculateLogP(), 1e-10);
+
+		// param=3.5 -> underlying x=0.5, logp=-0.5.
+		off = new OffsetReal();
+		off.initByName(
+				"distribution", new Exponential(null, new RealScalarParam<>(1, PositiveReal.INSTANCE)),
+				"offset", new RealScalarParam<>(3.0, Real.INSTANCE),
+				"param", new RealScalarParam<>(3.5, Real.INSTANCE));
+		assertEquals(-0.5, off.calculateLogP(), 1e-10);
+
+		// Normal(0,1): logp(0) = -0.5*log(2*pi).
+		Normal n01 = new Normal(null,
+				new RealScalarParam<>(0, Real.INSTANCE),
+				new RealScalarParam<>(1, PositiveReal.INSTANCE));
+		off = new OffsetReal();
+		off.initByName(
+				"distribution", n01,
+				"offset", new RealScalarParam<>(3.0, Real.INSTANCE),
+				"param", new RealScalarParam<>(3.0, Real.INSTANCE));
+		assertEquals(-0.5 * Math.log(2 * Math.PI), off.calculateLogP(), 1e-10);
+	}
+
 	BEASTInterface fromXML(String xml) throws XMLParserException {
 		return (new XMLParser()).parseBareFragment(xml, true);
 	}


### PR DESCRIPTION
Fixes #72.

## Summary

- `OffsetReal.calculateLogP()` evaluated the underlying distribution at `param - 2 * offset` instead of `param - offset`, because both the override and the `logDensity(x)` it called subtracted the offset.
- One-line fix: pass `param.get()` directly to `logDensity()`, matching the convention used by `density(x)` and `calcLogP(value)` in the same class.
- Added `testCalculateLogPOfOffsetReal` covering Exp and Normal cases (the existing `MeanOfParametricDistributionTest` only exercised `getMean()`).

No production callers of `OffsetReal.calculateLogP()` exist in beast3 today, so no MCMC results were affected. Downstream consumers (LPhyBeast) need this fixed before they can use `OffsetReal` as a prior.

## Test plan

- [x] `mvn test -Dtest=MeanOfParametricDistributionTest` — all 7 tests pass on the new branch
- [x] `mvn test -Dtest='*Distribution*Test,*Prior*Test'` — all 36 tests in beast-base pass