### PR TITLE
EmpiricalSubstitutionModel: normalize empirical frequencies

### DIFF
--- a/beast-base/src/main/java/beast/base/spec/evolution/substitutionmodel/EmpiricalSubstitutionModel.java
+++ b/beast-base/src/main/java/beast/base/spec/evolution/substitutionmodel/EmpiricalSubstitutionModel.java
@@ -83,8 +83,18 @@ public abstract class EmpiricalSubstitutionModel extends BasicGeneralSubstitutio
         int[] order = getEncodingOrder();
         int states = freqs.length;
         double [] freqsInOrder = new double[states];
+        double sum = 0.0;
         for (int i = 0; i < states; i++) {
         	freqsInOrder[i] = freqs[order[i]];
+        	sum += freqsInOrder[i];
+        }
+        // empirical frequencies published in papers are typically rounded to
+        // a few decimal places, so they don't sum to 1.0 exactly. Normalize
+        // so SimplexParam validation (tolerance 1e-10) passes.
+        if (sum > 0 && Math.abs(sum - 1.0) > 1e-10) {
+            for (int i = 0; i < states; i++) {
+                freqsInOrder[i] /= sum;
+            }
         }
         SimplexParam freqsRParam = new SimplexParam(freqsInOrder); // , 0.0, 1.0);
         Frequencies freqsParam = new Frequencies(freqsRParam);


### PR DESCRIPTION
## Summary

- Empirical amino-acid models (FLU, LG, WAG, etc.) report stationary frequencies rounded to a fixed number of decimal places, so the values typically sum to ~0.9999999 instead of exactly 1.0.
- `Simplex.isValid()` uses a 1e-10 tolerance; the rounding error is ~1e-7, so every empirical model fails initialisation when its frequencies are wrapped into a `SimplexParam`.
- Fix: normalize before constructing the `SimplexParam`. No-op when the values already sum to within 1e-10 of 1.0.

Arose while migrating [obama](https://github.com/alexeid/obama) where all 16 `OBAMA_<aa>` empirical models hit this.

## Test plan

- [ ] Run an XML that loads one of the OBAMA empirical models (e.g. `examples/testOBAMA.xml` on the obama beast3-migration branch) and confirm it parses past `EmpiricalSubstitutionModel.getEmpericalFrequencieValues()`.
- [ ] Confirm exact-simplex frequencies (e.g. `[0.25, 0.25, 0.25, 0.25]`) are unchanged.