### PR TITLE
Add missing @Deprecated annotations on three legacy classes

### DIFF
--- a/beast-base/src/main/java/beast/base/evolution/branchratemodel/BranchRateModel.java
+++ b/beast-base/src/main/java/beast/base/evolution/branchratemodel/BranchRateModel.java
@@ -14,6 +14,10 @@ public interface BranchRateModel {
 
     public double getRateForBranch(Node node);
 
+    /**
+     * @deprecated replaced by {@link beast.base.spec.evolution.branchratemodel.Base}
+     */
+    @Deprecated
     @Description(value = "Base implementation of a clock model.", isInheritable = false)
     public abstract class Base extends CalculationNode implements BranchRateModel {
         final public Input<Function> meanRateInput = new Input<>("clock.rate", "mean clock rate (defaults to 1.0)");

--- a/beast-base/src/main/java/beast/base/inference/operator/kernel/BactrianIntervalOperator.java
+++ b/beast-base/src/main/java/beast/base/inference/operator/kernel/BactrianIntervalOperator.java
@@ -14,6 +14,7 @@ import java.text.DecimalFormat;
  * @deprecated replaced by
  * {@link beast.base.spec.inference.operator.uniform.IntervalOperator}.
  */
+@Deprecated
 @Description("A scale operator that selects a random dimension of the real parameter and scales the value a " +
         "random amount according to a Bactrian distribution such that the parameter remains in its range. "
         + "Supposed to be more efficient than UniformOperator")

--- a/beast-fx/src/main/java/beastfx/app/beauti/PriorInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/beauti/PriorInputEditor.java
@@ -35,6 +35,13 @@ import beast.base.inference.parameter.IntegerParameter;
 import beast.base.inference.parameter.RealParameter;
 import beast.base.parser.PartitionContext;
 
+/**
+ * @deprecated BEAUti editor for the deprecated
+ * {@link beast.base.inference.distribution.Prior} wrapper. In the spec
+ * framework distributions take {@code param} directly (no Prior wrapper),
+ * so a separate prior editor is no longer needed.
+ */
+@Deprecated
 public class PriorInputEditor extends InputEditor.Base implements HasExpandBox {
 
 	public PriorInputEditor(BeautiDoc doc) {


### PR DESCRIPTION
## Summary

Three classes have spec replacements (or in the `PriorInputEditor` case, are tied to an already-deprecated wrapper) but are missing the `@Deprecated` annotation:

- **`BactrianIntervalOperator`** — already has a `@deprecated` Javadoc pointing at `beast.base.spec.inference.operator.uniform.IntervalOperator`, but no annotation. Tooling and IDE warnings rely on the annotation, not the Javadoc tag.
- **`BranchRateModel.Base`** — the legacy abstract base. Spec replacement at `beast.base.spec.evolution.branchratemodel.Base`.
- **`PriorInputEditor`** — BEAUti editor for the already-deprecated `Prior` wrapper. Not needed under the spec framework where distributions take a `param` input directly.

Each gains a Javadoc `@deprecated` pointer to the spec replacement (where one exists) and the `@Deprecated` annotation itself. Twelve added lines, no logic changes.

## Why it matters

Found via the [beast3-migration](https://github.com/CompEvol/beast3-migration) analyzer, which uses `@Deprecated` as the canonical signal for "this class has been replaced." Without these annotations the analyzer can't warn downstream packages (BEASTLabs, sampled-ancestors, flc, …) that they're extending a class slated for removal, and IDEs can't show the strikethrough on usages.

## Test plan

- [x] `mvn -q -DskipTests compile` — clean
- [x] `mvn -q -DskipTests test-compile` — clean
- [ ] Maintainer review of the chosen spec replacement targets in the Javadoc