### PR TITLE
Point OneOnX @deprecated at LogUniform

### DIFF
--- a/beast-base/src/main/java/beast/base/inference/distribution/OneOnX.java
+++ b/beast-base/src/main/java/beast/base/inference/distribution/OneOnX.java
@@ -7,7 +7,11 @@ import org.apache.commons.statistics.distribution.ContinuousDistribution;
 
 
 /**
- * @deprecated 1/x can be simulated. Use other distributions.
+ * @deprecated use {@link beast.base.spec.inference.distribution.LogUniform} instead —
+ * it has density proportional to 1/x on a bounded support [lower, upper] (lower > 0),
+ * which makes it a proper, normalisable replacement for this improper 1/x prior.
+ * Set {@code lower}/{@code upper} to the range of plausible values for the quantity
+ * being prior'd (e.g. clock rates, population sizes).
  */
 @Deprecated
 @Description("OneOnX distribution.  f(x) = C/x for some normalizing constant C. " +


### PR DESCRIPTION
## Summary

`OneOnX`'s deprecation message previously said only "1/x can be simulated. Use other distributions" — which leaves migrators (and downstream tooling) guessing what to substitute. `LogUniform` is the natural proper replacement: its density `1 / (x · log(upper/lower))` on `[lower, upper]` is, on its support, proportional to `1/x`. Unlike the legacy improper `1/x` prior it's normalisable and can be sampled from directly.

Point the `@deprecated` body explicitly at `LogUniform` so a future migrator can read the replacement off the javadoc, and so deprecation-aware tooling can produce a non-empty hint without hand-curated mappings.

## Test plan

- [x] `mvn -q compile` succeeds locally
- [x] The deprecated-class scan in [CompEvol/beast3-migration](https://github.com/CompEvol/beast3-migration) now resolves `beast.base.inference.distribution.OneOnX` → `beast.base.spec.inference.distribution.LogUniform` automatically via its javadoc-fallback (89 → 90 of 105 deprecated classes carry an automated spec replacement).
- [ ] CI on this branch.
