### PR TITLE
Fix auto-optimisation direction for Bactrian scale factor (#96)

### DIFF
--- a/beast-base/src/main/java/beast/base/spec/evolution/operator/IntervalScaleOperator.java
+++ b/beast-base/src/main/java/beast/base/spec/evolution/operator/IntervalScaleOperator.java
@@ -38,10 +38,10 @@ public class IntervalScaleOperator extends TreeOperator {
     protected KernelDistribution kernelDistribution;
 
 
-    final public Input<Double> scaleUpperLimit = new Input<>("upper", "Upper Limit of scale factor", 1.0 - 1e-8);
+    final public Input<Double> scaleUpperLimit = new Input<>("upper", "Upper Limit of scale factor", 10.0);
     final public Input<Double> scaleLowerLimit = new Input<>("lower", "Lower limit of scale factor", 1e-8);
 
-    public final Input<Double> scaleFactorInput = new Input<>("scaleFactor", "scaling factor: range from 0 to 1. Close to zero is very large jumps, close to 1.0 is very small jumps.", 0.75);
+    public final Input<Double> scaleFactorInput = new Input<>("scaleFactor", "scale of the Bactrian kernel: close to zero is very small jumps, larger values give larger jumps.", 0.75);
 
     final public Input<Boolean> optimiseInput = new Input<>("optimise",
 			"flag to indicate that the scale factor is automatically changed in order to achieve a good acceptance rate (default true)",

--- a/beast-base/src/main/java/beast/base/spec/inference/operator/AbstractScale.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/operator/AbstractScale.java
@@ -17,7 +17,7 @@ public abstract class AbstractScale extends KernelOperator {
             "scale of the Bactrian kernel: close to zero is very small jumps, " +
                     "larger values give larger jumps.", 0.75);
     final public Input<Double> scaleUpperLimit = new Input<>("upper",
-            "Upper Limit of scale factor", 1.0 - 1e-8);
+            "Upper Limit of scale factor", 10.0);
     final public Input<Double> scaleLowerLimit = new Input<>("lower",
             "Lower limit of scale factor", 1e-8);
 
@@ -40,10 +40,6 @@ public abstract class AbstractScale extends KernelOperator {
     public void initAndValidate() {
         super.initAndValidate();
         scaleFactor = scaleFactorInput.get();
-        //TODO why?
-        if (scaleUpperLimit.get() == 1 - 1e-8) {
-            scaleUpperLimit.setValue(10.0, this);
-        }
         upper = scaleUpperLimit.get();
         lower = scaleLowerLimit.get();
     }

--- a/beast-base/src/main/java/beast/base/spec/inference/operator/AbstractScale.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/operator/AbstractScale.java
@@ -14,8 +14,8 @@ import java.text.DecimalFormat;
 public abstract class AbstractScale extends KernelOperator {
 
     public final Input<Double> scaleFactorInput = new Input<>("scaleFactor",
-            "scaling factor: range from 0 to 1. Close to zero is very large jumps, " +
-                    "close to 1.0 is very small jumps.", 0.75);
+            "scale of the Bactrian kernel: close to zero is very small jumps, " +
+                    "larger values give larger jumps.", 0.75);
     final public Input<Double> scaleUpperLimit = new Input<>("upper",
             "Upper Limit of scale factor", 1.0 - 1e-8);
     final public Input<Double> scaleLowerLimit = new Input<>("lower",
@@ -79,9 +79,16 @@ public abstract class AbstractScale extends KernelOperator {
     @Override
     public void optimize(final double logAlpha) {
         if (optimiseInput.get()) {
+            // The scaleFactor here is the Bactrian kernel scale: larger scaleFactor means
+            // larger jumps (lower acceptance), the opposite of the legacy ScaleOperator
+            // where scaleFactor close to 0 meant large jumps. Tune multiplicatively so the
+            // direction matches the kernel: acceptance too high (delta > 0) increases the
+            // scaleFactor, acceptance too low (delta < 0) decreases it. The legacy
+            // 1/(exp(delta + log(1/sf - 1)) + 1) transform inverted this and broke (NaN)
+            // for scaleFactor >= 1.
             double delta = calcDelta(logAlpha);
-            delta += Math.log(1.0 / scaleFactor - 1.0);
-            setCoercableParameterValue(1.0 / (Math.exp(delta) + 1.0));
+            delta += Math.log(scaleFactor);
+            setCoercableParameterValue(Math.exp(delta));
         }
     }
 

--- a/beast-base/src/main/java/beast/base/spec/inference/operator/ScaleOperator.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/operator/ScaleOperator.java
@@ -233,15 +233,6 @@ public class ScaleOperator extends AbstractScale {
         return getScaler(i, Double.NaN);
     }
 
-    @Override
-    public void optimize(double logAlpha) {
-        // must be overridden by operator implementation to have an effect
-        if (optimiseInput.get()) {
-            double delta = calcDelta(logAlpha);
-            double scaleFactor = getCoercableParameterValue();
-            delta += Math.log(scaleFactor);
-            scaleFactor = Math.exp(delta);
-            setCoercableParameterValue(scaleFactor);
-        }
-    }
+    // optimize(logAlpha) is inherited from AbstractScale, which tunes the Bactrian
+    // scaleFactor multiplicatively in the correct direction.
 } // class ScaleOperator


### PR DESCRIPTION
Fixes #96.

The spec scale operators draw from a Bactrian kernel (`scale = exp(scaleFactor * N(0,1))`), so larger `scaleFactor` means larger jumps / lower acceptance — the opposite of the legacy `ScaleOperator`.

## Changes

- `AbstractScale.optimize()` tunes multiplicatively in the kernel direction (`sf *= exp(delta)`): acceptance too high increases the scale factor, too low decreases it. The old legacy transform ran the optimiser backwards and went `NaN` for `scaleFactor >= 1`.
- The scale factor upper limit defaults to `10.0` directly in `AbstractScale` and `IntervalScaleOperator`, giving the optimiser the headroom it needs above 1. This removes the brittle `initAndValidate` hack that bumped the legacy `1 - 1e-8` default to `10.0` via a floating-point equality check (which also silently overrode a deliberate user value).
- Removed the now-redundant `optimize()` override in `ScaleOperator`.
- Corrected the `scaleFactor` input descriptions, which documented the inverted legacy semantics.

`IntervalScaleOperator` extends `TreeOperator` (separate hierarchy); its `optimize()` already tuned in the correct direction but its upper limit was still capped at ~1.0, so it is fixed here too.

## Testing

`mvn -pl beast-base compile` succeeds.