### PR TITLE
Grant JavaFX native access to silence Java 25 launch warnings

### DIFF
--- a/release/Linux/linuxbin/applauncher
+++ b/release/Linux/linuxbin/applauncher
@@ -44,11 +44,11 @@ else
 fi
 
 if [ -n "$BEAST_EXTRA_LIBS" ]; then
-  exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+  exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
       -Xss256m -Xmx8g -Djava.library.path="$BEAST_EXTRA_LIBS" -Duser.language=en -Dfile.encoding=UTF-8 \
       -m beast.pkgmgmt/beast.pkgmgmt.launcher.AppLauncherLauncher "$@"
 else
-  exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+  exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
       -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
       -m beast.pkgmgmt/beast.pkgmgmt.launcher.AppLauncherLauncher "$@"
 fi

--- a/release/Linux/linuxbin/beast
+++ b/release/Linux/linuxbin/beast
@@ -69,6 +69,6 @@ if [ -n "$BEAST_EXTRA_LIBS" ]; then
 	fi
 fi
 
-exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
     -Xss256m -Xmx8g -Djava.library.path="$LD_LIBRARY_PATH" -Duser.language=en -Dfile.encoding=UTF-8 \
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.BeastLauncher "$@"

--- a/release/Linux/linuxbin/beauti
+++ b/release/Linux/linuxbin/beauti
@@ -25,6 +25,6 @@ JAVA_HOME="$BUNDLE_HOME/jre"
 export JAVA_HOME
 JAVA="$JAVA_HOME/bin/java"
 APP="$BUNDLE_HOME/lib"
-exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.BeautiLauncher -capture "$@"

--- a/release/Linux/linuxbin/loganalyser
+++ b/release/Linux/linuxbin/loganalyser
@@ -44,11 +44,11 @@ else
 fi
 
 if [ -n "$BEAST_EXTRA_LIBS" ]; then
-  exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+  exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
       -Xss256m -Xmx8g -Djava.library.path="$BEAST_EXTRA_LIBS" -Duser.language=en -Dfile.encoding=UTF-8 \
       -m beast.pkgmgmt/beast.pkgmgmt.launcher.AppLauncherLauncher beastfx.app.tools.LogAnalyser "$@"
 else
-  exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+  exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
       -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
       -m beast.pkgmgmt/beast.pkgmgmt.launcher.AppLauncherLauncher beastfx.app.tools.LogAnalyser "$@"
 fi

--- a/release/Linux/linuxbin/logcombiner
+++ b/release/Linux/linuxbin/logcombiner
@@ -25,6 +25,6 @@ JAVA_HOME="$BUNDLE_HOME/jre"
 export JAVA_HOME
 JAVA="$JAVA_HOME/bin/java"
 APP="$BUNDLE_HOME/lib"
-exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.LogCombinerLauncher "$@"

--- a/release/Linux/linuxbin/packagemanager
+++ b/release/Linux/linuxbin/packagemanager
@@ -25,6 +25,6 @@ JAVA_HOME="$BUNDLE_HOME/jre"
 export JAVA_HOME
 JAVA="$JAVA_HOME/bin/java"
 APP="$BUNDLE_HOME/lib"
-exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
     -m beast.pkgmgmt/beast.pkgmgmt.PackageManager "$@"

--- a/release/Linux/linuxbin/treeannotator
+++ b/release/Linux/linuxbin/treeannotator
@@ -25,6 +25,6 @@ JAVA_HOME="$BUNDLE_HOME/jre"
 export JAVA_HOME
 JAVA="$JAVA_HOME/bin/java"
 APP="$BUNDLE_HOME/lib"
-exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+exec "$JAVA" --module-path "$APP" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.TreeAnnotatorLauncher "$@"

--- a/release/Mac/build-sign-dmg.sh
+++ b/release/Mac/build-sign-dmg.sh
@@ -226,7 +226,8 @@ sed -i '' 's|^app\.mainclass=.*|app.mainmodule=beast.pkgmgmt/beast.pkgmgmt.launc
 # media) come along automatically.
 sed -i '' '/^\[JavaOptions\]/a\
 java-options=--module-path=\$APPDIR\
-java-options=--add-modules=ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject
+java-options=--add-modules=ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject\
+java-options=--enable-native-access=javafx.graphics,javafx.media,javafx.web
 ' "$BEAST_CFG"
 
 # jpackage may strip bin/java from the bundled runtime (it uses its own native
@@ -295,12 +296,12 @@ build_wrapper_app() {
     local launch_cmd
     if [ -n "$extra_args" ]; then
         launch_cmd="exec \"\$BEAST_APP/runtime/Contents/Home/bin/java\" \\
-    --module-path \"\$BEAST_APP/app\" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \\
+    --module-path \"\$BEAST_APP/app\" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \\
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \\
     -m $module_name/$main_class $extra_args \"\$@\""
     else
         launch_cmd="exec \"\$BEAST_APP/runtime/Contents/Home/bin/java\" \\
-    --module-path \"\$BEAST_APP/app\" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \\
+    --module-path \"\$BEAST_APP/app\" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \\
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \\
     -m $module_name/$main_class \"\$@\""
     fi

--- a/release/Mac/macbin/applauncher
+++ b/release/Mac/macbin/applauncher
@@ -45,12 +45,12 @@ fi
 
 if [ -n "$BEAST_EXTRA_LIBS" ]; then
   "$JAVA" -Dlauncher.wait.for.exit=true \
-      --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+      --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
       -Xss256m -Xmx8g -Djava.library.path="$BEAST_EXTRA_LIBS" -Duser.language=en -Dfile.encoding=UTF-8 \
       -m beast.pkgmgmt/beast.pkgmgmt.launcher.AppLauncherLauncher "$@"
 else
   "$JAVA" -Dlauncher.wait.for.exit=true \
-      --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+      --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
       -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
       -m beast.pkgmgmt/beast.pkgmgmt.launcher.AppLauncherLauncher "$@"
 fi

--- a/release/Mac/macbin/beast
+++ b/release/Mac/macbin/beast
@@ -71,6 +71,6 @@ if [ -n "$BEAST_EXTRA_LIBS" ]; then
 fi
 
 "$JAVA" -Dlauncher.wait.for.exit=true \
-    --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+    --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
     -Xss256m -Xmx8g -Djava.library.path="$LD_LIBRARY_PATH" -Duser.language=en -Dfile.encoding=UTF-8 \
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.BeastLauncher "$@"

--- a/release/Mac/macbin/beauti
+++ b/release/Mac/macbin/beauti
@@ -27,6 +27,6 @@ BEAST_APP="$BEAST/BEAST.app/Contents"
 export JAVA_HOME="$BEAST_APP/runtime/Contents/Home"
 JAVA="$JAVA_HOME/bin/java"
 "$JAVA" -Dlauncher.wait.for.exit=true \
-    --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+    --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.BeautiLauncher -capture "$@"

--- a/release/Mac/macbin/loganalyser
+++ b/release/Mac/macbin/loganalyser
@@ -45,12 +45,12 @@ fi
 
 if [ -n "$BEAST_EXTRA_LIBS" ]; then
   "$JAVA" -Dlauncher.wait.for.exit=true \
-      --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+      --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
       -Xss256m -Xmx8g -Djava.library.path="$BEAST_EXTRA_LIBS" -Duser.language=en -Dfile.encoding=UTF-8 \
       -m beast.pkgmgmt/beast.pkgmgmt.launcher.AppLauncherLauncher beastfx.app.tools.LogAnalyser "$@"
 else
   "$JAVA" -Dlauncher.wait.for.exit=true \
-      --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+      --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
       -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
       -m beast.pkgmgmt/beast.pkgmgmt.launcher.AppLauncherLauncher beastfx.app.tools.LogAnalyser "$@"
 fi

--- a/release/Mac/macbin/logcombiner
+++ b/release/Mac/macbin/logcombiner
@@ -27,6 +27,6 @@ BEAST_APP="$BEAST/BEAST.app/Contents"
 export JAVA_HOME="$BEAST_APP/runtime/Contents/Home"
 JAVA="$JAVA_HOME/bin/java"
 "$JAVA" -Dlauncher.wait.for.exit=true \
-    --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+    --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.LogCombinerLauncher "$@"

--- a/release/Mac/macbin/packagemanager
+++ b/release/Mac/macbin/packagemanager
@@ -27,6 +27,6 @@ BEAST_APP="$BEAST/BEAST.app/Contents"
 export JAVA_HOME="$BEAST_APP/runtime/Contents/Home"
 JAVA="$JAVA_HOME/bin/java"
 "$JAVA" \
-    --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+    --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
     -m beast.pkgmgmt/beast.pkgmgmt.PackageManager "$@"

--- a/release/Mac/macbin/treeannotator
+++ b/release/Mac/macbin/treeannotator
@@ -27,6 +27,6 @@ BEAST_APP="$BEAST/BEAST.app/Contents"
 export JAVA_HOME="$BEAST_APP/runtime/Contents/Home"
 JAVA="$JAVA_HOME/bin/java"
 "$JAVA" -Dlauncher.wait.for.exit=true \
-    --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject \
+    --module-path "$BEAST_APP/app" --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web \
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 \
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.TreeAnnotatorLauncher "$@"

--- a/release/Windows/assemble-bundle.sh
+++ b/release/Windows/assemble-bundle.sh
@@ -232,7 +232,7 @@ for cfg in "$BUNDLE/app/"*.cfg; do
     sed -i \
         -e '/^app\.classpath/d' \
         -e 's|^app\.mainclass=\(.*\)|app.mainmodule=beast.pkgmgmt/\1|' \
-        -e '/^\[JavaOptions\]/a java-options=--module-path=$APPDIR\njava-options=--add-modules=ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject' \
+        -e '/^\[JavaOptions\]/a java-options=--module-path=$APPDIR\njava-options=--add-modules=ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject\njava-options=--enable-native-access=javafx.graphics,javafx.media,javafx.web' \
         "$cfg"
 done
 

--- a/release/Windows/bat/applauncher.bat
+++ b/release/Windows/bat/applauncher.bat
@@ -2,6 +2,6 @@
 set "BUNDLE_HOME=%~dp0.."
 "%BUNDLE_HOME%\runtime\bin\java.exe" ^
     --module-path "%BUNDLE_HOME%\app" ^
-    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject ^
+    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web ^
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 ^
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.AppLauncherLauncher %*

--- a/release/Windows/bat/beast.bat
+++ b/release/Windows/bat/beast.bat
@@ -2,6 +2,6 @@
 set "BUNDLE_HOME=%~dp0.."
 "%BUNDLE_HOME%\runtime\bin\java.exe" ^
     --module-path "%BUNDLE_HOME%\app" ^
-    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject ^
+    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web ^
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 ^
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.BeastLauncher %*

--- a/release/Windows/bat/beauti.bat
+++ b/release/Windows/bat/beauti.bat
@@ -2,6 +2,6 @@
 set "BUNDLE_HOME=%~dp0.."
 "%BUNDLE_HOME%\runtime\bin\java.exe" ^
     --module-path "%BUNDLE_HOME%\app" ^
-    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject ^
+    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web ^
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 ^
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.BeautiLauncher -capture %*

--- a/release/Windows/bat/loganalyser.bat
+++ b/release/Windows/bat/loganalyser.bat
@@ -2,6 +2,6 @@
 set "BUNDLE_HOME=%~dp0.."
 "%BUNDLE_HOME%\runtime\bin\java.exe" ^
     --module-path "%BUNDLE_HOME%\app" ^
-    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject ^
+    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web ^
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 ^
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.AppLauncherLauncher beastfx.app.tools.LogAnalyser %*

--- a/release/Windows/bat/logcombiner.bat
+++ b/release/Windows/bat/logcombiner.bat
@@ -2,6 +2,6 @@
 set "BUNDLE_HOME=%~dp0.."
 "%BUNDLE_HOME%\runtime\bin\java.exe" ^
     --module-path "%BUNDLE_HOME%\app" ^
-    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject ^
+    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web ^
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 ^
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.LogCombinerLauncher %*

--- a/release/Windows/bat/packagemanager.bat
+++ b/release/Windows/bat/packagemanager.bat
@@ -2,6 +2,6 @@
 set "BUNDLE_HOME=%~dp0.."
 "%BUNDLE_HOME%\runtime\bin\java.exe" ^
     --module-path "%BUNDLE_HOME%\app" ^
-    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject ^
+    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web ^
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 ^
     -m beast.pkgmgmt/beast.pkgmgmt.PackageManager %*

--- a/release/Windows/bat/treeannotator.bat
+++ b/release/Windows/bat/treeannotator.bat
@@ -2,6 +2,6 @@
 set "BUNDLE_HOME=%~dp0.."
 "%BUNDLE_HOME%\runtime\bin\java.exe" ^
     --module-path "%BUNDLE_HOME%\app" ^
-    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject ^
+    --add-modules ALL-MODULE-PATH,javafx.controls,javafx.fxml,javafx.swing,javafx.web,jdk.jsobject --enable-native-access=javafx.graphics,javafx.media,javafx.web ^
     -Xss256m -Xmx8g -Duser.language=en -Dfile.encoding=UTF-8 ^
     -m beast.pkgmgmt/beast.pkgmgmt.launcher.TreeAnnotatorLauncher %*


### PR DESCRIPTION
## Problem

On Java 25, launching any GUI app (BEAUti, AppLauncher, etc.) prints:

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by com.sun.glass.utils.NativeLibLoader in module javafx.graphics (jrt:/javafx.graphics)
WARNING: Use --enable-native-access=javafx.graphics to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

JavaFX loads its native libraries via `System::load`. Without native access explicitly granted, Java 25 warns — and a future release will **block** the call outright, which would break the GUI.

## Fix

Add `--enable-native-access=javafx.graphics,javafx.media,javafx.web` next to the existing `--add-modules ...javafx...` in every launcher:

- Linux `release/Linux/linuxbin/*`
- Mac `release/Mac/macbin/*`
- Windows `release/Windows/bat/*`
- The jpackage `.cfg` / wrapper-`.app` generators (`release/Mac/build-sign-dmg.sh`, `release/Windows/assemble-bundle.sh`) so packaged bundles stay in sync with the static scripts.

All three modules listed load native code and are guaranteed resolved (`javafx.web → javafx.media → javafx.graphics`), so no "Unknown module" warning is introduced. Targeting all three (rather than just `javafx.graphics`) prevents the same warning resurfacing from WebView/media later.

Reported by Remco testing the Linux user bundle.