### PR TITLE
Include source jar in BEAST.base and BEAST.app package zips

### DIFF
--- a/beast-base/src/assembly/package.xml
+++ b/beast-base/src/assembly/package.xml
@@ -3,6 +3,7 @@
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 http://maven.apache.org/xsd/assembly-2.1.1.xsd">
     <!-- Builds the installable BEAST.base package zip:
            version.xml          (the BEAST.base package descriptor, at repo root)
+           BEAST.base.src.jar   the package sources, at the zip root (BEAST2 convention)
            lib/beast-base.jar    + its third-party runtime dependencies
            examples/             example XML (+ nexus data) shown in BEAUti
          beast-pkgmgmt is excluded: it is the bootstrap/launcher and is always
@@ -26,6 +27,15 @@
         <file>
             <source>${project.basedir}/../version.xml</source>
             <outputDirectory>.</outputDirectory>
+        </file>
+        <!-- Source jar at the zip root as BEAST.base.src.jar, matching the BEAST2
+             convention (<PackageName>.src.jar). The -sources.jar is built by
+             maven-source-plugin (jar-no-fork) in the same package phase, ordered
+             before the assembly execution so it exists when this runs. -->
+        <file>
+            <source>${project.build.directory}/${project.build.finalName}-sources.jar</source>
+            <outputDirectory>.</outputDirectory>
+            <destName>BEAST.base.src.jar</destName>
         </file>
     </files>
 

--- a/beast-fx/src/assembly/package.xml
+++ b/beast-fx/src/assembly/package.xml
@@ -3,6 +3,7 @@
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 http://maven.apache.org/xsd/assembly-2.1.1.xsd">
     <!-- Builds the installable BEAST.app package zip:
            version.xml          (the BEAST.app package descriptor)
+           BEAST.app.src.jar    the package sources, at the zip root (BEAST2 convention)
            lib/beast-fx.jar
          Only beast-fx.jar is bundled. Its dependencies are provided at runtime:
          beast-base (the BEAST.base package), beast-pkgmgmt (the bootstrap), and
@@ -25,6 +26,15 @@
         <file>
             <source>${project.basedir}/version.xml</source>
             <outputDirectory>.</outputDirectory>
+        </file>
+        <!-- Source jar at the zip root as BEAST.app.src.jar, matching the BEAST2
+             convention (<PackageName>.src.jar). The -sources.jar is built by
+             maven-source-plugin (jar-no-fork) in the same package phase, ordered
+             before the assembly execution so it exists when this runs. -->
+        <file>
+            <source>${project.build.directory}/${project.build.finalName}-sources.jar</source>
+            <outputDirectory>.</outputDirectory>
+            <destName>BEAST.app.src.jar</destName>
         </file>
     </files>
 


### PR DESCRIPTION
## What

Ship the module sources inside the `BEAST.base` and `BEAST.app` package zips, matching the previous BEAST2 layout (requested by Remco).

The source jar is placed at the **zip root** following the BEAST2 convention `<PackageName>.src.jar`:

```
BEAST.base.package.v*.zip
  version.xml
  BEAST.base.src.jar   ← new
  lib/…  examples/…

BEAST.app.package.v*.zip
  version.xml
  BEAST.app.src.jar    ← new
  lib/beast-fx-*.jar
```

## How

`maven-source-plugin` (`jar-no-fork`) already produces a `-sources.jar` for every module in the `package` phase, ordered before the assembly execution. So each `src/assembly/package.xml` just adds a `<file>` entry that copies that jar to the zip root and renames it to `<PackageName>.src.jar` — no new build steps.

This is exactly the name and location that `PackageHealthChecker.checkSourceCode()` and the legacy installer in `BeastLauncher` already look for (source jar/zip at the package top level), so it satisfies the health check too. The src jar rides along automatically when the release scripts copy these zips into the bundle — no release-script changes needed.

## Verified

Built both modules and confirmed the zips contain the src jar at the root: `BEAST.base.src.jar` (401 `.java` files) and `BEAST.app.src.jar` (197 `.java` files).