### PR TITLE
Make spec RandomTree recognise spec MRCAPrior constraints

### DIFF
--- a/beast-base/src/main/java/beast/base/spec/evolution/tree/coalescent/RandomTree.java
+++ b/beast-base/src/main/java/beast/base/spec/evolution/tree/coalescent/RandomTree.java
@@ -33,15 +33,15 @@ import beast.base.core.Input.Validate;
 import beast.base.core.Log;
 import beast.base.evolution.alignment.Alignment;
 import beast.base.evolution.alignment.TaxonSet;
-import beast.base.evolution.tree.MRCAPrior;
 import beast.base.evolution.tree.Node;
 import beast.base.evolution.tree.TraitSet;
 import beast.base.evolution.tree.Tree;
 import beast.base.evolution.tree.coalescent.PopulationFunction;
 import beast.base.inference.StateNode;
 import beast.base.inference.StateNodeInitialiser;
-import beast.base.inference.distribution.ParametricDistribution;
 import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.evolution.tree.MRCAPrior;
+import beast.base.spec.inference.distribution.ScalarDistribution;
 import beast.base.spec.type.RealScalar;
 import beast.base.util.HeapSort;
 import beast.base.util.Randomizer;
@@ -87,7 +87,7 @@ public class RandomTree extends Tree implements StateNodeInitialiser {
     List<Set<String>> taxonSets;
 
     // list of parametric distribution constraining the MRCA of taxon sets, null if not present
-    List<ParametricDistribution> distributions;
+    List<ScalarDistribution> distributions;
 
     // hard bound for the set, if any
     List<Bound> m_bounds;
@@ -224,7 +224,7 @@ public class RandomTree extends Tree implements StateNodeInitialiser {
 	                }
 	                usedTaxa.add(taxonID);
 	            }
-	            final ParametricDistribution distr = prior.distInput.get();
+	            final ScalarDistribution distr = prior.distInput.get();
 	            final Bound bounds = new Bound();
 	            if (distr != null) {
 	        		List<BEASTInterface> beastObjects = new ArrayList<>();
@@ -233,8 +233,8 @@ public class RandomTree extends Tree implements StateNodeInitialiser {
 	        			beastObjects.get(i).initAndValidate();
 	        		}
 	                try {
-	                	double tLow = distr.inverseCumulativeProbability(0.0);
-	                	double tHi = distr.inverseCumulativeProbability(1.0);
+	                	double tLow = ((Number) distr.inverseCumulativeProbability(0.0)).doubleValue();
+	                	double tHi = ((Number) distr.inverseCumulativeProbability(1.0)).doubleValue();
 						bounds.lower = getDate(tLow);
 		                bounds.upper = getDate(tHi);
 		                if (bounds.lower > bounds.upper && tLow < tHi) {

--- a/beast-base/src/test/java/test/beast/core/LoggerTest.java
+++ b/beast-base/src/test/java/test/beast/core/LoggerTest.java
@@ -22,8 +22,28 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class LoggerTest {
     Logger logger;
 
+    /**
+     * Logger.sampleOffset is protected static, so it is not reachable from this package
+     * directly; a subclass can reach it because protected static members are inherited
+     * regardless of package.
+     */
+    private static class LoggerGlobals extends Logger {
+        static void reset() {
+            Logger.sampleOffset = -1;
+        }
+    }
+
     @BeforeEach
     public void setUp() throws Exception {
+        // file.name.prefix, Logger.FILE_MODE and Logger.sampleOffset are JVM-wide globals
+        // that the integration tests set and do not restore (see XMLPathUtil.setUpOutputDir
+        // and ResumeTest). Whether this class runs before or after them varies between
+        // surefire runs, which made testFileLog fail intermittently: a stale prefix sends
+        // the log to <prefix>beast.log while the assertions resolve "beast.log" against the
+        // working directory, and a stale sampleOffset is added to every logged sample.
+        System.clearProperty("file.name.prefix");
+        Logger.FILE_MODE = Logger.LogFileMode.only_new;
+        LoggerGlobals.reset();
         logger = new Logger();
     }
 


### PR DESCRIPTION
## Problem

`beast.base.spec.evolution.tree.coalescent.RandomTree` still imported the **legacy** `beast.base.evolution.tree.MRCAPrior`. The spec `MRCAPrior` extends `Distribution` directly rather than subclassing the legacy class, so the `instanceof MRCAPrior` scan over the tree's outputs never matched and monophyletic constraints were **silently dropped** when initialising the starting tree.

Any calibrated analysis then starts from a random tree that violates its own monophyly constraints:

```
Start likelihood: -Infinity after 10 initialisation attempts
    P(HumanGorilla.prior) = -Infinity
    P(MonkeyApe.prior) = NaN  **
    ...
java.lang.RuntimeException: Could not find a proper state to initialise. Perhaps try another seed.
```

Reproduced on seeds 1, 7, 42 and 12345 — it is not seed-dependent.

There was no XML-level workaround: `calibrationsInput` was typed to the legacy class too, so an explicit `<constraint idref="..."/>` would fail type-checking, and legacy `MRCAPrior.distInput` requires a `ParametricDistribution` while spec priors are `ScalarDistribution` — incompatible hierarchies.

## Impact

This is not limited to one package. `beast-fx/src/main/resources/beast.fx/fxtemplates/Standard.xml` pairs spec `RandomTree` with spec `MRCAPrior`, so **every calibrated analysis produced by BEAUti under BEAST 3 is affected**.

## Fix

Switch the import, `calibrationsInput` and the `distributions` list to the spec `MRCAPrior` / `ScalarDistribution` types. `ScalarDistribution.inverseCumulativeProbability` returns a boxed value, so it is unboxed explicitly when computing the calibration bounds.

The legacy `beast.base.evolution.tree.coalescent.RandomTree` is untouched, so legacy XMLs keep working through the legacy class. No other caller passes MRCAPriors into the spec class — `RandomTreeTest` constructs one without constraints and `RandomGeneTree` does not touch the constraint machinery.

## Verification

- Full beast3 suite: **BUILD SUCCESS**, 527 tests (47 pkgmgmt + 458 base + 22 fx), 0 failures.
- Found via bModelTest's `examples/beast2-paper.xml` (7 monophyletic clade calibrations), which failed to initialise on every seed before this change and now starts at a finite likelihood and samples normally:
  ```
  Start likelihood: -41052.324347071335
                0    -41052.3243              N    -39681.3021     -1371.0222
            10000    -26682.0022         2.0       -26499.3254      -182.6768
  ```
- The other two bModelTest examples were re-run as regression checks and are unaffected.

---

## Second commit: `LoggerTest` isolation

CI on this branch went red on `LoggerTest.testFileLog`, which is unrelated to the change above — it fails or passes purely on where surefire schedules it relative to the integration tests. Three JVM-wide globals are set by those tests and never restored: `file.name.prefix` (`XMLPathUtil.setUpOutputDir`), `Logger.FILE_MODE`, and `Logger.sampleOffset` (`ResumeTest`).

Run ordering is not stable between CI runs, which is why master has been green:

| Run | prefix-setting tests | `LoggerTest` | Result |
|---|---|---|---|
| master `29714663831` | 69, 70, 71 | 57 (before) | green |
| this branch `30044812322` | 26, 28, 30 | 58 (after) | red |

When `LoggerTest` runs second, `openLogFile()` prepends the stale prefix and writes to `<prefix>beast.log` while the test resolves `beast.log` against the working directory, so the existence check fails; and the stale `sampleOffset` is added to every logged sample, so the round-tripped sample number is off by the leaked offset.

Fixed by resetting all three in `setUp()`. Verified by forcing the ordering — with `-Dsurefire.runOrder=reversealphabetical` over `ExampleXmlParsingTest`, `ResumeTest` and `LoggerTest`, `testFileLog` fails on a clean tree before the change and passes after it, as it does under `alphabetical` and `filesystem` ordering. Full `beast-base` suite: 458 tests, 0 failures.
