### PR TITLE
Say what a type mismatch expected and what it got

### DIFF
--- a/beast-base/src/main/java/beast/base/core/Input.java
+++ b/beast-base/src/main/java/beast/base/core/Input.java
@@ -509,7 +509,7 @@ public class Input<T> {
                 }                
                 
             }
-            throw new RuntimeException("Input 102b: type mismatch for input " + getName());
+            throw new RuntimeException(typeMismatchMessage("102b", value, beastObject));
         } else {
             if (theClass.isAssignableFrom(value.getClass())) {
                 if (value instanceof BEASTInterface) {
@@ -703,6 +703,54 @@ public class Input<T> {
     public boolean isTensorClass(Class<?> rawType) {
         return Scalar.class.isAssignableFrom(rawType)
                 || Vector.class.isAssignableFrom(rawType);
+    }
+
+    /**
+     * Build a type-mismatch message that says which input failed, on which object,
+     * what it expected and what it was actually given.
+     *
+     * <p>The bare "type mismatch for input x" is very hard to act on: it names neither
+     * the expected nor the supplied type, and the surrounding XML parser error only
+     * points at the enclosing element, not at the offending child. Where the supplied
+     * value is a legacy BEAST 2 class and the input wants a BEAST 3 spec one -- by far
+     * the most common cause while packages are being migrated -- say so explicitly,
+     * because the two are usually indistinguishable by name.
+     *
+     * @param code       the error code to report, e.g. "102b"
+     * @param value      the value that could not be assigned
+     * @param beastObject the object whose input was being set, may be null
+     */
+    private String typeMismatchMessage(String code, Object value, BEASTInterface beastObject) {
+        final Class<?> expected = tensorClass != null ? tensorClass : theClass;
+        final String expectedName = expected == null ? "<unknown>" : expected.getName();
+        final String actualName = value == null ? "null" : value.getClass().getName();
+
+        final StringBuilder b = new StringBuilder();
+        b.append("Input ").append(code).append(": type mismatch for input '").append(getName()).append("'");
+        if (beastObject != null) {
+            b.append(" of ").append(beastObject.getClass().getName());
+            if (beastObject.getID() != null) {
+                b.append(" id='").append(beastObject.getID()).append("'");
+            }
+        }
+        b.append("\n  expected: ").append(expectedName);
+        if (tensorClass != null && theClass != null) {
+            // for a tensor input the domain is carried separately, e.g. RealScalar<PositiveReal>
+            b.append(" with domain ").append(theClass.getName());
+        }
+        b.append("\n  but got:  ").append(actualName);
+
+        if (expectedName.startsWith("beast.base.spec.")
+                && actualName.startsWith("beast.base.")
+                && !actualName.startsWith("beast.base.spec.")) {
+            final String simpleName = value.getClass().getSimpleName();
+            b.append("\n\n").append(actualName).append(" is a legacy BEAST 2 class, but this input expects")
+             .append(" a BEAST 3 spec class.\nIn XML this usually means a bare element name was used, as in")
+             .append(" <").append(simpleName).append(" name='").append(getName()).append("'>, which resolves")
+             .append(" to the legacy\nclass. Name the input and give it an explicit spec instead, as in")
+             .append(" <").append(getName()).append(" spec='beast.base.spec...'>.");
+        }
+        return b.toString();
     }
 
     /**

--- a/beast-base/src/test/java/test/beast/core/InputTypeMismatchMessageTest.java
+++ b/beast-base/src/test/java/test/beast/core/InputTypeMismatchMessageTest.java
@@ -1,0 +1,83 @@
+package test.beast.core;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import beast.base.inference.parameter.RealParameter;
+import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.inference.distribution.Exponential;
+import beast.base.spec.inference.parameter.RealScalarParam;
+import beast.base.spec.inference.parameter.RealVectorParam;
+
+/**
+ * A type mismatch has to say enough to be acted on.
+ *
+ * <p>The message used to read only "type mismatch for input mean", naming neither the
+ * expected nor the supplied type, and the XML parser error that wraps it points at the
+ * enclosing element rather than the offending child. Working out that a legacy BEAST 2
+ * class had been supplied where a BEAST 3 spec one was wanted meant reading the source
+ * of the class that declared the input.
+ */
+public class InputTypeMismatchMessageTest {
+
+    private static String mismatchMessageFor(Object badValue) {
+        Exponential exponential = new Exponential();
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> exponential.meanInput.setValue(badValue, exponential));
+        return e.getMessage();
+    }
+
+    /** Supplying a legacy RealParameter where a spec RealScalar is wanted. */
+    @Test
+    public void testMessageNamesInputExpectedAndActual() {
+        String msg = mismatchMessageFor(new RealParameter("1.0"));
+
+        assertTrue(msg.contains("'mean'"), "should name the offending input, was: " + msg);
+        assertTrue(msg.contains(Exponential.class.getName()),
+                "should name the object whose input failed, was: " + msg);
+        assertTrue(msg.contains("beast.base.spec.type.RealScalar"),
+                "should name the expected type, was: " + msg);
+        assertTrue(msg.contains(RealParameter.class.getName()),
+                "should name the supplied type, was: " + msg);
+    }
+
+    /**
+     * Legacy and spec classes often share a simple name, so the message has to be
+     * explicit that the supplied class is the BEAST 2 one.
+     */
+    @Test
+    public void testLegacyClassGetsMigrationHint() {
+        String msg = mismatchMessageFor(new RealParameter("1.0"));
+
+        assertTrue(msg.contains("legacy BEAST 2 class"),
+                "should flag the legacy/spec confusion, was: " + msg);
+        assertTrue(msg.contains("spec="),
+                "should show how to declare the input explicitly, was: " + msg);
+    }
+
+    /**
+     * A mismatch between two spec types -- here a vector where a scalar is wanted --
+     * has nothing to do with the migration and must not get the misleading hint.
+     */
+    @Test
+    public void testNonLegacyMismatchHasNoMigrationHint() {
+        String msg = mismatchMessageFor(
+                new RealVectorParam<>(new double[]{1.0, 2.0}, PositiveReal.INSTANCE));
+
+        assertTrue(msg.contains("'mean'"), "should still name the input, was: " + msg);
+        assertTrue(msg.contains(RealVectorParam.class.getName()),
+                "should name the supplied type, was: " + msg);
+        assertTrue(!msg.contains("legacy BEAST 2 class"),
+                "should not claim a legacy class was supplied, was: " + msg);
+    }
+
+    /** A correctly typed spec parameter is still accepted. */
+    @Test
+    public void testSpecParameterIsAccepted() {
+        Exponential exponential = new Exponential();
+        exponential.meanInput.setValue(new RealScalarParam<>(1.0, PositiveReal.INSTANCE), exponential);
+    }
+
+}


### PR DESCRIPTION
## Problem

A type mismatch reports only the input name:

```
Input 102b: type mismatch for input mean
```

It names neither the expected nor the supplied type. The `XMLParserException` that wraps it prints an "Error detected about here" path built from the *enclosing* element, not the offending child — `setInput` is handed the parent node and the child never reaches the message — so the reported location is only ever approximate. In practice, finding the cause means opening the source of whichever class declares the input.

This is worst during migration. A legacy BEAST 2 class and its BEAST 3 spec twin usually share a simple name, and in XML a bare element name silently resolves to the **legacy** class:

```xml
<Exponential name="distr">   <!-- beast.base.inference.distribution.Exponential -->
```

That is an easy mistake to make and a slow one to find — it cost a round trip on BEAST2-Dev/bModelTest#7, where the same message appeared with no indication that legacy-vs-spec was the issue.

## Change

Report the input, the object carrying it, the expected type with its domain, and the supplied type. When the supplied class is a legacy `beast.base` class where a `beast.base.spec` one is wanted, say so explicitly and show the `spec=` form.

Before:

```
Input 102b: type mismatch for input mean
```

After:

```
Input 102b: type mismatch for input 'mean' of beast.base.spec.inference.distribution.Exponential id='post'
  expected: beast.base.spec.type.RealScalar with domain beast.base.spec.domain.PositiveReal
  but got:  beast.base.inference.parameter.RealParameter

beast.base.inference.parameter.RealParameter is a legacy BEAST 2 class, but this input expects a BEAST 3 spec class.
In XML this usually means a bare element name was used, as in <RealParameter name='mean'>, which resolves to the legacy
class. Name the input and give it an explicit spec instead, as in <mean spec='beast.base.spec...'>.
```

Scope is deliberately narrow: only the `102b` branch, which carried no type information at all. Error `101` already reports both types and `XMLParser` special-cases it, so it is left alone to avoid duplicated text.

## Tests

`InputTypeMismatchMessageTest` covers the four cases: the message names input, owner, expected and actual; a legacy class gets the migration hint; a spec-vs-spec mismatch (vector where a scalar is wanted) does **not** get a misleading hint; and a correctly typed parameter is still accepted.

Full `beast-base` suite: 462 tests, 0 failures.

## Not addressed

The "Error detected about here" location still points at the enclosing element. Fixing that means threading the child `Node` through `NameValuePair` into `setInput`, which is a larger change — happy to do it separately if wanted.