### PR TITLE
Stop registering the legacy SiteModelInputEditor as a BEAUti editor

### DIFF
--- a/beast-fx/src/main/java/module-info.java
+++ b/beast-fx/src/main/java/module-info.java
@@ -76,7 +76,12 @@ open module beast.fx {
         beastfx.app.inputeditor.OutFileListInputEditor,
         beastfx.app.inputeditor.ParameterInputEditor,
         beastfx.app.inputeditor.ParametricDistributionInputEditor,
-        beastfx.app.inputeditor.SiteModelInputEditor,
+        // The legacy SiteModelInputEditor is intentionally NOT provided: the spec
+        // SiteModelInputEditor (below) is the BEAUti editor for SiteModelInterface.Base in
+        // 2.8. Both declared the same type(), so registering both let ServiceLoader order
+        // decide the winner, and the legacy one could win and emit legacy operators (e.g.
+        // BactrianDeltaExchangeOperator instead of the spec DeltaExchangeOperator). The
+        // class remains for LegacyStandard.xml's connect-method references.
         beastfx.app.inputeditor.StringInputEditor,
         beastfx.app.inputeditor.TreeFileInputEditor,
         beastfx.app.inputeditor.TreeFileListInputEditor,

--- a/beast-fx/version.xml
+++ b/beast-fx/version.xml
@@ -57,7 +57,10 @@
                 <provider classname="beastfx.app.inputeditor.OutFileListInputEditor"/>
                 <provider classname="beastfx.app.inputeditor.ParameterInputEditor"/>
                 <provider classname="beastfx.app.inputeditor.ParametricDistributionInputEditor"/>
-                <provider classname="beastfx.app.inputeditor.SiteModelInputEditor"/>
+                <!-- Legacy SiteModelInputEditor intentionally not registered: the spec
+                     SiteModelInputEditor is the BEAUti editor for SiteModelInterface.Base
+                     in 2.8. Registering both let service order pick the winner, and the
+                     legacy one could emit legacy operators. -->
                 <provider classname="beastfx.app.inputeditor.StringInputEditor"/>
                 <provider classname="beastfx.app.inputeditor.TreeFileInputEditor"/>
                 <provider classname="beastfx.app.inputeditor.TreeFileListInputEditor"/>


### PR DESCRIPTION
## Problem

beast-fx registers **two** editors for the site model — `beastfx.app.inputeditor.SiteModelInputEditor` (legacy) and `beastfx.app.inputeditor.spec.SiteModelInputEditor` — and **both declare `type() == SiteModelInterface.Base`**. They are registered in both service declarations: `module-info.java` (`provides ... InputEditor with`) and `version.xml`.

`InputEditorFactory` keys editors in a `HashMap<Class<?>, editor>`:

```java
for (Class<?> type : editor.types())
    inputEditorMap.put(type, inputEditor);   // last registration wins
```

So with two editors claiming the same type, whichever is registered **last** wins — and that order comes from `ServiceLoader`, which differs between launch environments. When the **legacy** editor wins, the Site Model panel produces **legacy operators**: `FixMeanMutationRatesOperator` is created as a `BactrianDeltaExchangeOperator` instead of the spec `DeltaExchangeOperator`. That is wrong for a 2.8 spec analysis, and it makes downstream editors that build on it fail non-deterministically by launch mode — e.g. bModelTest's `BEASTModelTestInputEditor`, whose `super.init` cast of that plugin threw a `ClassCastException` for one user but not in other setups (BEAST2-Dev/bModelTest#8).

## Change

Remove the legacy `SiteModelInputEditor` from both service declarations, so the spec editor is the sole editor for `SiteModelInterface.Base`. The class itself stays — `LegacyStandard.xml` references its `avmnConnector`/`customConnector` as connect **methods**, which does not require it to be a registered `InputEditor` service.

## Verification

- `beast-fx` `BeautiSimpleTest` passes.
- No test loads `LegacyStandard.xml`.

**Scope note for reviewers:** editor discovery differs between a module-path launch (`module-info provides`) and a class-path launch (`version.xml`), which is why both are edited. The intended behavior — spec editor selected, spec operators produced — should be confirmed in a real module-path BEAUti launch; I verified the no-regression path and the diagnosis, but a class-path test harness is not a faithful oracle for editor selection here.