### PR TITLE
Log the exception when BEAUti fails to switch a model

### DIFF
--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BEASTObjectInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BEASTObjectInputEditor.java
@@ -237,6 +237,9 @@ public class BEASTObjectInputEditor extends InputEditor.Base {
                     try {
                         beastObject = selected.createSubNet(doc.getContextFor(beastObject), m_beastObject, m_input, true);
                     } catch (Exception ex) {
+                        // also log to the console: the dialog alone leaves no trace, which
+                        // makes selection failures (e.g. BEAST2-Dev/bModelTest#9) undiagnosable
+                        ex.printStackTrace();
                         Alert.showMessageDialog(null, "Could not select beastObject: " +
                                 ex.getClass().getName() + " " +
                                 ex.getMessage()


### PR DESCRIPTION
When selecting a value in a model dropdown fails, the combo handler in `BEASTObjectInputEditor.addComboBox` shows a dialog:

```
Could not select beastObject: <class> <message>
```

but never logs the exception, so there is no stack trace to diagnose from. This is the situation in BEAST2-Dev/bModelTest#9: switching the substitution model to HKY while "BEAST Model Test" is the site model pops a dialog with **nothing in the console**. With the stack trace restored, the real cause is visible:

```
java.lang.RuntimeException: Cannot find template for removing RevJump.s:dna
    at beastfx.app.inputeditor.BeautiSubTemplate.removeSubNet(BeautiSubTemplate.java:308)
    at beastfx.app.inputeditor.BeautiSubTemplate.createSubNet(BeautiSubTemplate.java:315)
    at beastfx.app.inputeditor.BEASTObjectInputEditor.lambda$addComboBox$0(BEASTObjectInputEditor.java:238)
```

This PR just adds `ex.printStackTrace()` before the dialog, so selection failures are diagnosable. (The `Cannot find template for removing` failure itself is a separate matter — `removeSubNet` throws when no `BeautiSubTemplate` matches the model being replaced.)