### PR TITLE
Fix BEAUti crash for single valued distr inputs (ScalarDistributionInputEditor)

### DIFF
--- a/beast-fx/src/main/java/beastfx/app/inputeditor/ScalarDistributionInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/ScalarDistributionInputEditor.java
@@ -49,6 +49,8 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
 
     boolean useDefaultBehavior;
 	boolean mayBeUnstable;
+	/** object that owns m_input -- not necessarily the distribution being edited **/
+	BEASTInterface inputOwner;
 
     @Override
     public Class<?> type() {
@@ -65,21 +67,29 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
     public void init(Input<?> input, BEASTInterface beastObject, int itemNr, ExpandOption isExpandOption, boolean addButtons) {
         // useDefaultBehavior = !((beastObject instanceof beast.base.inference.distribution.Prior) || beastObject instanceof MRCAPrior || beastObject instanceof TreeDistribution);
         
-    	if (scalarTemplates == null) {
+        // m_beastObject is set to the distribution below, so keep track of the
+        // object that owns the input being edited as well
+        inputOwner = beastObject;
+
+    	ScalarDistribution<?,?> currentDist = getDistribution(input, itemNr);
+    	if (scalarTemplates == null && currentDist != null) {
     		Input<ScalarDistribution<?,?>> _input = new Input<>("param", "dummy input");
         	_input.setType(ScalarDistribution.class);
-        	scalarTemplates = doc.getInputEditorFactory().getAvailableTemplates(_input, beastObject, null, doc);
+        	List<BeautiSubTemplate> templates = doc.getInputEditorFactory().getAvailableTemplates(_input, beastObject, null, doc);
 
-        	templateInstances = new ArrayList<>();
-        	templateDomains = new ArrayList<>();
-            List<?> list = (List<?>) input.get();
-            PartitionContext context = doc.getContextFor((BEASTInterface) list.get(itemNr));
-            ScalarDistribution<?,?> prior1 = (ScalarDistribution <?,?>) list.get(itemNr);
-        	for (BeautiSubTemplate template : scalarTemplates) {
-            	ScalarDistribution<?,?> newDist = (ScalarDistribution<?,?>) template.createSubNet(context, prior1, _input, true);
-            	templateInstances.add(newDist);
-            	templateDomains.add(getDomain(newDist));
+        	List<ScalarDistribution<?,?>> instances = new ArrayList<>();
+        	List<Class<?>> domains = new ArrayList<>();
+            PartitionContext context = contextFor(currentDist);
+        	for (BeautiSubTemplate template : templates) {
+            	ScalarDistribution<?,?> newDist = (ScalarDistribution<?,?>) template.createSubNet(context, currentDist, _input, true);
+            	instances.add(newDist);
+            	domains.add(getDomain(newDist));
         	}
+        	// only publish the caches once they are complete, so that a failure
+        	// half way cannot leave them inconsistent for later editors
+        	templateInstances = instances;
+        	templateDomains = domains;
+        	scalarTemplates = templates;
     	}
     	
     	
@@ -90,7 +100,10 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
         m_input = input;
 
         if (beastObject instanceof ScalarDistribution<?, ?>) {
-            m_beastObject = beastObject;        	
+            m_beastObject = beastObject;
+        } else if (currentDist != null) {
+        	// editing a distribution valued input, e.g. the distr input of a Prior
+            m_beastObject = currentDist;
         } else {
         	// m_input = beastObject.getInput("distr");
             m_beastObject = (ScalarDistribution<?, ?>) beastObject.getInput("distr").get();
@@ -116,7 +129,10 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
         } else {
         	pane = new HBox();
         }
-        pane.getChildren().add(createComboBox(m_beastObject, m_input));
+        ComboBox<BeautiSubTemplate> distrComboBox = createComboBox(m_beastObject, m_input);
+        if (distrComboBox != null) {
+        	pane.getChildren().add(distrComboBox);
+        }
     	pane.setPadding(new Insets(5));
         if (m_beastObject != null) {
         	FXUtils.createHMCButton(pane, m_beastObject, m_input);
@@ -132,9 +148,11 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
 	            Button rangeButton = new Button(paramToString(p));
 	            rangeButton.setOnAction(e -> {
 	                Button rangeButton1 = (Button) e.getSource();
-	
-	                List<?> list = (List<?>) m_input.get();
-	                ScalarDistribution<?,?> prior1 = (ScalarDistribution<?,?>) list.get(itemNr);
+
+	                ScalarDistribution<?,?> prior1 = getDistribution(m_input, itemNr);
+	                if (prior1 == null || prior1.paramInput.get() == null) {
+	                	return;
+	                }
 	                BEASTInterface p1 = (BEASTInterface) prior1.paramInput.get();
 	                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, RealScalar.class, doc);
 	                if (dlg.showDialog()) {
@@ -153,9 +171,11 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
 	            Button rangeButton = new Button(paramToString(p));
 	            rangeButton.setOnAction(e -> {
 	                Button rangeButton1 = (Button) e.getSource();
-	
-	                List<?> list = (List<?>) m_input.get();
-	                ScalarDistribution<?,?> prior1 = (ScalarDistribution<?,?>) list.get(itemNr);
+
+	                ScalarDistribution<?,?> prior1 = getDistribution(m_input, itemNr);
+	                if (prior1 == null || prior1.paramInput.get() == null) {
+	                	return;
+	                }
 	                BEASTInterface p1 = (BEASTInterface) prior1.paramInput.get();
 	                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, IntScalar.class, doc);
 	                if (dlg.showDialog()) {
@@ -181,6 +201,43 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
 //        getChildren().add(pane);
 
     } // init
+
+
+	/**
+	 * The distribution being edited, which is either the itemNr-th entry of a list
+	 * of distributions (e.g. the priors panel), or the value of the input itself
+	 * when the editor is created for a single ScalarDistribution input,
+	 * like the distr input of a Prior. Returns null if neither applies.
+	 */
+	private ScalarDistribution<?,?> getDistribution(Input<?> input, int itemNr) {
+		if (input == null) {
+			return null;
+		}
+		Object o = input.get();
+		if (o instanceof List<?> list) {
+			if (itemNr < 0 || itemNr >= list.size()) {
+				return null;
+			}
+			o = list.get(itemNr);
+		}
+		return o instanceof ScalarDistribution<?,?> dist ? dist : null;
+	}
+
+
+	/**
+	 * Partition context of a distribution. Distributions nested inside another
+	 * distribution need not have an ID of their own, in which case the context of
+	 * the object owning the input is used.
+	 */
+	private PartitionContext contextFor(BEASTInterface dist) {
+		if (dist != null && dist.getID() != null) {
+			return doc.getContextFor(dist);
+		}
+		if (inputOwner != null && inputOwner.getID() != null) {
+			return doc.getContextFor(inputOwner);
+		}
+		return new PartitionContext("");
+	}
 
 
 	private Class<?> getDomain(ScalarDistribution<?, ?> value) {
@@ -605,6 +662,10 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
 	private ComboBox<BeautiSubTemplate> comboBox;
 
 	protected ComboBox<BeautiSubTemplate> createComboBox(BEASTInterface m_beastObject, Input<?> m_input) {
+		if (scalarTemplates == null || templateDomains == null || templateDomains.size() != scalarTemplates.size()) {
+			// templates could not be collected, so there is nothing to choose from
+			return null;
+		}
 		ComboBox<BeautiSubTemplate> comboBox = new ComboBox<>();
 
         TensorDistribution<?,?> prior = (TensorDistribution<?,?>) m_beastObject;
@@ -680,11 +741,11 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
 
             
             try {
-	            if (m_input.get() instanceof List) {
+	            if (m_input.get() instanceof List<?> l && itemNr >= 0 && itemNr < l.size()) {
 		            List<Distribution> list = (List<Distribution>) m_input.get();
 		
 		            BeautiSubTemplate template = (BeautiSubTemplate) comboBox1.getValue();
-		            PartitionContext context = doc.getContextFor((BEASTInterface) list.get(itemNr));
+		            PartitionContext context = contextFor((BEASTInterface) list.get(itemNr));
 		            
 		            Object item = list.get(itemNr);
 		            if (item instanceof ScalarDistribution<?,?>) {
@@ -706,8 +767,11 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
 	            } else {
 		    		
 		            BeautiSubTemplate template = (BeautiSubTemplate) comboBox1.getValue();
-		            PartitionContext context = doc.getContextFor((BEASTInterface) m_beastObject);
-	            	ScalarDistribution<?,?> newDist = (ScalarDistribution<?,?>) template.createSubNet(context, m_beastObject, m_input, true);
+		            PartitionContext context = contextFor(m_beastObject);
+		            // the new distribution becomes the value of m_input, so it must be
+		            // registered as output of the object owning that input
+		            BEASTInterface owner = inputOwner != null ? inputOwner : m_beastObject;
+	            	ScalarDistribution<?,?> newDist = (ScalarDistribution<?,?>) template.createSubNet(context, owner, m_input, true);
 	            }
             } catch (Exception e1) {
                 e1.printStackTrace();

--- a/beast-fx/src/test/java/test/beastfx/app/inputeditor/ScalarDistributionInputEditorTest.java
+++ b/beast-fx/src/test/java/test/beastfx/app/inputeditor/ScalarDistributionInputEditorTest.java
@@ -1,0 +1,168 @@
+package test.beastfx.app.inputeditor;
+
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import beast.base.core.BEASTInterface;
+import beast.base.core.Input;
+import beast.base.core.Input.Validate;
+import beast.base.inference.Distribution;
+import beast.base.inference.State;
+import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.domain.Real;
+import beast.base.spec.domain.UnitInterval;
+import beast.base.spec.inference.distribution.Beta;
+import beast.base.spec.inference.distribution.ScalarDistribution;
+import beast.base.spec.inference.parameter.RealScalarParam;
+import beast.base.spec.type.RealScalar;
+import beastfx.app.inputeditor.BeautiConfig;
+import beastfx.app.inputeditor.BeautiDoc;
+import beastfx.app.inputeditor.InputEditor;
+import beastfx.app.inputeditor.ScalarDistributionInputEditor;
+import javafx.application.Platform;
+import javafx.stage.Stage;
+
+
+/**
+ * ScalarDistributionInputEditor is used both for entries of a list of distributions
+ * (as in the priors panel) and for single ScalarDistribution valued inputs, like the
+ * distr input of a Prior. This tests the latter, which is how packages such as
+ * bModelTest wrap a distribution inside another Distribution.
+ */
+@ExtendWith(ApplicationExtension.class)
+public class ScalarDistributionInputEditorTest {
+
+	/** Distribution with a single ScalarDistribution valued input, like bModelTest's BMTPrior **/
+	public static class DistrWrapper extends Distribution {
+		public Input<ScalarDistribution<RealScalar<? extends Real>, Double>> distInput = new Input<>("distr",
+				"distribution the prior applies to", Validate.REQUIRED);
+
+		@Override
+		public void initAndValidate() {}
+
+		@Override
+		public double calculateLogP() {
+			return 0;
+		}
+
+		@Override
+		public List<String> getArguments() {
+			return new ArrayList<>();
+		}
+
+		@Override
+		public List<String> getConditions() {
+			return new ArrayList<>();
+		}
+
+		@Override
+		public void sample(State state, Random random) {}
+	}
+
+
+	@Start
+	public void start(Stage stage) {
+		// nothing to show, only the JavaFX toolkit is required
+	}
+
+	/** the editor caches templates in static fields, so do not leak them into other tests **/
+	@BeforeEach
+	@AfterEach
+	public void clearTemplateCache() throws Exception {
+		for (String name : new String[] {"scalarTemplates", "templateInstances", "templateDomains"}) {
+			Field field = ScalarDistributionInputEditor.class.getDeclaredField(name);
+			field.setAccessible(true);
+			field.set(null, null);
+		}
+	}
+
+
+	@Test
+	public void testEditorForSingleValuedDistrInput() throws Exception {
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		List<Throwable> failures = new ArrayList<>();
+		runOnFXThread(() -> {
+			BeautiDoc doc = new BeautiDoc();
+			doc.loadTemplate(doc.processTemplate(BeautiConfig.TEMPLATE_DIR + "/Standard.xml"));
+
+			// more than one wrapper, since a failure for the first one used to leave
+			// the static template cache half initialised, making every editor after
+			// it fail with an unrelated IndexOutOfBoundsException
+			for (int i = 0; i < 2; i++) {
+				DistrWrapper wrapper = new DistrWrapper();
+				Beta beta = new Beta();
+				beta.initByName(
+						"alpha", new RealScalarParam<>(1.0, PositiveReal.INSTANCE),
+						"beta", new RealScalarParam<>(4.0, PositiveReal.INSTANCE));
+				beta.setID("Beta" + i + ".s:test");
+				wrapper.initByName("distr", asRealScalarDistribution(beta));
+				wrapper.setID("wrapperPrior" + i + ".s:test");
+				doc.registerPlugin(beta);
+				doc.registerPlugin(wrapper);
+
+				// this is what BEAUti does for every input of an object shown in a panel
+				try {
+					InputEditor editor = doc.getInputEditorFactory().createInputEditor(
+							(Input<?>) wrapper.distInput, (BEASTInterface) wrapper, doc);
+					assertNotNull(editor, "no input editor created for distr input");
+				} catch (Throwable e) {
+					e.printStackTrace();
+					failures.add(e);
+				}
+			}
+		}, error);
+
+		if (error.get() != null) {
+			error.get().printStackTrace();
+			fail("test could not be run: " + error.get());
+		}
+		if (!failures.isEmpty()) {
+			fail("could not create input editor for distr input: " + failures);
+		}
+	}
+
+
+	@SuppressWarnings("unchecked")
+	private static ScalarDistribution<RealScalar<? extends Real>, Double> asRealScalarDistribution(
+			ScalarDistribution<RealScalar<UnitInterval>, Double> dist) {
+		return (ScalarDistribution<RealScalar<? extends Real>, Double>) (ScalarDistribution<?, ?>) dist;
+	}
+
+
+	/** run task on the JavaFX application thread, recording any exception in error **/
+	private static void runOnFXThread(FXTask task, AtomicReference<Throwable> error) throws InterruptedException {
+		CountDownLatch latch = new CountDownLatch(1);
+		Platform.runLater(() -> {
+			try {
+				task.run();
+			} catch (Throwable e) {
+				error.set(e);
+			} finally {
+				latch.countDown();
+			}
+		});
+		if (!latch.await(120, TimeUnit.SECONDS)) {
+			throw new AssertionError("timed out waiting for JavaFX thread");
+		}
+	}
+
+	private interface FXTask {
+		void run() throws Exception;
+	}
+}


### PR DESCRIPTION
## Problem

Opening the Priors panel in BEAUti with a package that wraps a distribution in another `Distribution` — e.g. bModelTest's `BMTPrior`, which has a single `ScalarDistribution` valued `distr` input — pops up "Could not add entry for distr" (BEAST2-Dev/bModelTest#10):

```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at beastfx.app.inputeditor.ScalarDistributionInputEditor.createComboBox(ScalarDistributionInputEditor.java:627)
	at beastfx.app.inputeditor.ScalarDistributionInputEditor.init(ScalarDistributionInputEditor.java:119)
	at beastfx.app.inputeditor.InputEditorFactory.createInputEditor(InputEditorFactory.java:264)
	at beastfx.app.inputeditor.InputEditorFactory.createInputEditor(InputEditorFactory.java:145)
```

`init()` assumed the input is always a list of distributions with a valid item number:

```java
List<?> list = (List<?>) input.get();
PartitionContext context = doc.getContextFor((BEASTInterface) list.get(itemNr));
```

For a single valued `distr` input this is reached with the distribution itself as value and `itemNr == -1`, so it throws. `scalarTemplates` had already been assigned at that point while `templateDomains` was still empty, so every editor created afterwards skipped the `scalarTemplates == null` guard and died on `templateDomains.get(k++)` — the reported symptom. The combo box change handler already had a branch for non-list inputs, so single valued inputs were clearly meant to be supported.

## Fix

- resolve the distribution being edited from either the list entry or the value of the input itself (`getDistribution`)
- publish the template caches only once they are complete, so a failure can no longer leave them inconsistent
- fall back to the partition context of the object owning the input when the nested distribution has no ID of its own (`contextFor`)
- register a replacement distribution as output of the object owning the input rather than of the distribution it replaces
- suppress the combo box, rather than throw, when no templates are known, and null check it before adding it to the pane

## Test

`ScalarDistributionInputEditorTest` builds a `BeautiDoc` from the Standard template and asks `InputEditorFactory` for an editor for the `distr` input of a `Distribution` wrapper twice, which is what BEAUti does when rendering a panel. Without the fix it reproduces both the initial `ClassCastException` and the `IndexOutOfBoundsException` from the issue; with the fix it passes.

Full `beast-fx` suite: 23 run, 0 failures, 0 errors (11 skipped).
