### PR TITLE
Fix "Could not add entry for distr" when adding an MRCAPrior

### DIFF
--- a/beast-fx/src/main/java/beastfx/app/inputeditor/InputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/InputEditor.java
@@ -308,7 +308,8 @@ public abstract class Base extends Pane implements InputEditor {
     }
 
     protected String formatName(String name) {
-	    if (doc.beautiConfig.inputLabelMap.containsKey(m_beastObject.getClass().getName() + "." + name)) {
+    	// m_beastObject can be null when the input has no value to edit yet
+	    if (m_beastObject != null && doc.beautiConfig.inputLabelMap.containsKey(m_beastObject.getClass().getName() + "." + name)) {
 	        name = doc.beautiConfig.inputLabelMap.get(m_beastObject.getClass().getName() + "." + name);
 	    } else {
 	        name = name.replaceAll("([a-z])([A-Z])", "$1 $2");

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/ScalarDistributionInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/ScalarDistributionInputEditor.java
@@ -72,7 +72,11 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
         inputOwner = beastObject;
 
     	ScalarDistribution<?,?> currentDist = getDistribution(input, itemNr);
-    	if (scalarTemplates == null && currentDist != null) {
+    	if (scalarTemplates == null && (currentDist != null || beastObject != null)) {
+    		// the templates are only used to populate the combo box, so they can be
+    		// collected even when there is no distribution to edit yet, in which case
+    		// the object owning the input takes its place
+    		BEASTInterface templateOwner = currentDist != null ? currentDist : beastObject;
     		Input<ScalarDistribution<?,?>> _input = new Input<>("param", "dummy input");
         	_input.setType(ScalarDistribution.class);
         	List<BeautiSubTemplate> templates = doc.getInputEditorFactory().getAvailableTemplates(_input, beastObject, null, doc);
@@ -81,7 +85,7 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
         	List<Class<?>> domains = new ArrayList<>();
             PartitionContext context = contextFor(currentDist);
         	for (BeautiSubTemplate template : templates) {
-            	ScalarDistribution<?,?> newDist = (ScalarDistribution<?,?>) template.createSubNet(context, currentDist, _input, true);
+            	ScalarDistribution<?,?> newDist = (ScalarDistribution<?,?>) template.createSubNet(context, templateOwner, _input, true);
             	instances.add(newDist);
             	domains.add(getDomain(newDist));
         	}
@@ -106,10 +110,12 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
             m_beastObject = currentDist;
         } else {
         	// m_input = beastObject.getInput("distr");
-            m_beastObject = (ScalarDistribution<?, ?>) beastObject.getInput("distr").get();
+        	// m_beastObject remains null when there is no distribution to edit,
+        	// e.g. the distr input of an MRCAPrior that was just added
+            m_beastObject = distrOf(beastObject);
         }
 
-        if (useDefaultBehavior && (beastObject instanceof MRCAPrior)) {
+        if (useDefaultBehavior && (beastObject instanceof MRCAPrior) && m_beastObject != null) {
         	useDefaultBehavior = false;
         	pane = new HBox();
         	expandedInit(input, beastObject);
@@ -124,10 +130,15 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
         //m_bAddButtons = true;
         
 		this.itemNr = itemNr;
-        if (input.get() != null) {
+		boolean paneAdded = false;
+        if (input.get() != null && m_beastObject != null) {
             super.init(input, m_beastObject, itemNr, ExpandOption.FALSE, m_bAddButtons);
+            paneAdded = true;
         } else {
+        	// there is nothing to edit, so only offer a combo box to select a
+        	// distribution from, labelled with the name of the input
         	pane = new HBox();
+        	addInputLabel();
         }
         ComboBox<BeautiSubTemplate> distrComboBox = createComboBox(m_beastObject, m_input);
         if (distrComboBox != null) {
@@ -195,12 +206,26 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
         
         
 //        Pane pane1 = pane;
-        registerAsListener(pane);        
+        registerAsListener(pane);
 //        pane = FXUtils.newHBox();
 //        pane.getChildren().add(pane1);
 //        getChildren().add(pane);
+        if (!paneAdded) {
+        	// super.init() adds the pane it creates itself, this one still needs adding
+        	getChildren().add(pane);
+        }
 
     } // init
+
+
+	/**
+	 * The ScalarDistribution held by the distr input of beastObject, or null if
+	 * there is no such input, or it has no value.
+	 */
+	private ScalarDistribution<?,?> distrOf(BEASTInterface beastObject) {
+		Input<?> distr = beastObject.getInputs().get("distr");
+		return distr != null && distr.get() instanceof ScalarDistribution<?,?> dist ? dist : null;
+	}
 
 
 	/**
@@ -354,7 +379,10 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
     @Override
     /** suppress input label**/
     protected void addInputLabel() {
-        String name = formatName(m_beastObject.getID());
+    	// the label is the ID of the distribution being edited, but there need not
+    	// be a distribution, in which case fall back to the name of the input
+    	String id = m_beastObject != null ? m_beastObject.getID() : null;
+        String name = formatName(id != null ? id : m_input.getName());
         boolean b = m_bAddButtons;
         m_bAddButtons = true;
         addInputLabel(name, m_input.getTipText());
@@ -856,6 +884,10 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
 	private String getParameters() {
     	StringBuilder b = null;
     	TensorDistribution<?,?> distr = (TensorDistribution<?,?>) m_beastObject;
+    	if (distr == null) {
+    		// no distribution selected yet, so there are no parameters to show
+    		return "";
+    	}
     	for (Input<?> input: distr.listInputs()) {
     		if (!input.getName().equals("param")) {
     		Object o = input.get();

--- a/beast-fx/src/test/java/test/beastfx/app/beauti/BeautiBase.java
+++ b/beast-fx/src/test/java/test/beastfx/app/beauti/BeautiBase.java
@@ -16,6 +16,8 @@ import beastfx.app.inputeditor.AlignmentListInputEditor.Partition0;
 import beastfx.app.inputeditor.BeautiConfig;
 import beastfx.app.inputeditor.BeautiDoc;
 import javafx.application.Platform;
+import javafx.geometry.Bounds;
+import javafx.geometry.Rectangle2D;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.ObservableList;
 import javafx.embed.swing.SwingFXUtils;
@@ -26,6 +28,8 @@ import javafx.scene.control.*;
 import javafx.scene.image.WritableImage;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.Pane;
+import javafx.stage.Screen;
+import javafx.stage.Window;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.api.FxRobot;
@@ -578,6 +582,7 @@ System.err.println("Trying to load " + dir + " " + files[0]);
 			}
 		    return false;
 		}).queryAs(Node.class);
+		moveOnScreen(robot, node);
 		robot.clickOn(node);
 		return robot;
 	}
@@ -589,12 +594,36 @@ System.err.println("Trying to load " + dir + " " + files[0]);
 		});
 		Set<Node> nodes = q.queryAll();
 		if (nodes.size() > 0) {
-			robot.clickOn((Node)(nodes.toArray()[0]));
+			Node node = (Node)(nodes.toArray()[0]);
+			moveOnScreen(robot, node);
+			robot.clickOn(node);
 		}
 //		for (Node node : nodes) {
 //			robot.clickOn(node);
 //		}
 		return robot;
+	}
+
+	/**
+	 * Clicks are delivered to a point on the screen, so a node that lies outside the
+	 * screen can never be clicked. Windows are cascaded down the screen as they are
+	 * created, and BEAUti windows are nearly as high as the screen, so nodes at the
+	 * bottom of a window drop off the screen once enough windows have been opened in
+	 * the same JVM -- which depends on how many tests ran before. Move the window so
+	 * that the node is on the screen.
+	 */
+	private void moveOnScreen(FxRobot robot, Node node) {
+		Window window = node.getScene().getWindow();
+		Bounds bounds = node.localToScreen(node.getBoundsInLocal());
+		Rectangle2D screen = Screen.getPrimary().getVisualBounds();
+		double dx = Math.max(bounds.getMaxX() - screen.getMaxX(), 0);
+		double dy = Math.max(bounds.getMaxY() - screen.getMaxY(), 0);
+		if (dx > 0 || dy > 0) {
+			robot.interact(() -> {
+				window.setX(Math.max(window.getX() - dx, screen.getMinX()));
+				window.setY(Math.max(window.getY() - dy, screen.getMinY()));
+			});
+		}
 	}
 
     protected void setPartitionTableCell(FxRobot robot, int col, String string) {

--- a/beast-fx/src/test/java/test/beastfx/app/beauti/BeautiMRCAPriorTest.java
+++ b/beast-fx/src/test/java/test/beastfx/app/beauti/BeautiMRCAPriorTest.java
@@ -1,0 +1,103 @@
+package test.beastfx.app.beauti;
+
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import beastfx.app.beauti.BeautiTabPane;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.DialogPane;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+
+
+/**
+ * An MRCA prior is added without a distribution, which used to make BEAUti pop up a
+ * "Could not add entry for distr" message, both when the prior was added and every
+ * time the priors panel was shown again (issue #128).
+ */
+@ExtendWith(ApplicationExtension.class)
+public class BeautiMRCAPriorTest extends BeautiBase {
+
+	@Start
+	public void start(Stage stage) {
+		System.setProperty("beast.is.junit.testing", "true");
+		try {
+			BeautiTabPane tabPane = BeautiTabPane.main2(new String[] {}, stage);
+			this.doc = tabPane.doc;
+			stage.show();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+
+	@Test
+	public void addMRCAPriorWithoutDistribution(FxRobot robot) throws Exception {
+		// a single partition, so that adding the prior does not ask for a tree first
+		importAlignment(NEXUS_DIR, new File("anolis.nex"));
+		WaitForAsyncUtils.waitForFxEvents();
+
+		selectTab(robot, "Priors");
+		scrollToBottom(robot);
+		clickOnButtonWithText(robot, "+ Add Prior");
+
+		robot.clickOn("#idEntry").write("twoAnolis");
+		robot.clickOn("#listOfTaxonCandidates").clickOn("Anolis_ahli");
+		clickOnButtonWithText(robot, ">>");
+		robot.clickOn("OK");
+
+		// the prior has no distribution at this point, which is what used to fail
+		assertNoMessageShowing(robot, "after adding an MRCA prior");
+
+		// the priors panel is rebuilt every time it is shown
+		selectTab(robot, "MCMC");
+		selectTab(robot, "Priors");
+		assertNoMessageShowing(robot, "after returning to the priors panel");
+
+		// and picking a distribution should still work
+		clickOnNodesWithID(robot, "twoAnolis.prior.distr");
+		robot.clickOn("Normal");
+		WaitForAsyncUtils.waitForFxEvents();
+		assertNoMessageShowing(robot, "after selecting a distribution");
+	}
+
+
+	/** fail if BEAUti is showing a message dialog **/
+	private void assertNoMessageShowing(FxRobot robot, String when) {
+		for (Window window : robot.listWindows()) {
+			if (window.isShowing() && window.getScene() != null) {
+				DialogPane pane = findDialogPane(window.getScene().getRoot());
+				if (pane != null) {
+					fail("unexpected message " + when + ": " + pane.getContentText());
+				}
+			}
+		}
+	}
+
+
+	/** first dialog pane in the node tree rooted at node, or null if there is none **/
+	private DialogPane findDialogPane(Node node) {
+		if (node instanceof DialogPane dialogPane) {
+			return dialogPane;
+		}
+		if (node instanceof Parent parent) {
+			for (Node child : parent.getChildrenUnmodifiable()) {
+				DialogPane dialogPane = findDialogPane(child);
+				if (dialogPane != null) {
+					return dialogPane;
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/beast-fx/src/test/java/test/beastfx/app/inputeditor/ScalarDistributionInputEditorTest.java
+++ b/beast-fx/src/test/java/test/beastfx/app/inputeditor/ScalarDistributionInputEditorTest.java
@@ -27,6 +27,7 @@ import beast.base.inference.State;
 import beast.base.spec.domain.PositiveReal;
 import beast.base.spec.domain.Real;
 import beast.base.spec.domain.UnitInterval;
+import beast.base.spec.evolution.tree.MRCAPrior;
 import beast.base.spec.inference.distribution.Beta;
 import beast.base.spec.inference.distribution.ScalarDistribution;
 import beast.base.spec.inference.parameter.RealScalarParam;
@@ -36,6 +37,9 @@ import beastfx.app.inputeditor.BeautiDoc;
 import beastfx.app.inputeditor.InputEditor;
 import beastfx.app.inputeditor.ScalarDistributionInputEditor;
 import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.ComboBox;
 import javafx.stage.Stage;
 
 
@@ -135,6 +139,65 @@ public class ScalarDistributionInputEditorTest {
 		if (!failures.isEmpty()) {
 			fail("could not create input editor for distr input: " + failures);
 		}
+	}
+
+
+	/**
+	 * An MRCAPrior starts out without a distribution, which used to make the editor
+	 * for its distr input throw a NullPointerException, so that BEAUti popped up a
+	 * "Could not add entry for distr" message when the prior was added (issue #128).
+	 */
+	@Test
+	public void testEditorForMRCAPriorWithoutDistribution() throws Exception {
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		List<Throwable> failures = new ArrayList<>();
+		AtomicReference<InputEditor> editor = new AtomicReference<>();
+		runOnFXThread(() -> {
+			BeautiDoc doc = new BeautiDoc();
+			doc.loadTemplate(doc.processTemplate(BeautiConfig.TEMPLATE_DIR + "/Standard.xml"));
+
+			MRCAPrior prior = new MRCAPrior();
+			prior.setID("allTaxa.prior");
+			doc.registerPlugin(prior);
+
+			// this is what BEAUti does for every input of an item in the priors panel
+			try {
+				editor.set(doc.getInputEditorFactory().createInputEditor(
+						(Input<?>) prior.distInput, (BEASTInterface) prior, doc));
+			} catch (Throwable e) {
+				e.printStackTrace();
+				failures.add(e);
+			}
+		}, error);
+
+		if (error.get() != null) {
+			error.get().printStackTrace();
+			fail("test could not be run: " + error.get());
+		}
+		if (!failures.isEmpty()) {
+			fail("could not create input editor for distr input without distribution: " + failures);
+		}
+		assertNotNull(editor.get(), "no input editor created for distr input");
+		// the editor should offer a way to select a distribution
+		assertNotNull(findComboBox(editor.get().getComponent()),
+				"no combo box to select a distribution from");
+	}
+
+
+	/** first combo box in the node tree rooted at node, or null if there is none **/
+	private static ComboBox<?> findComboBox(Node node) {
+		if (node instanceof ComboBox<?> comboBox) {
+			return comboBox;
+		}
+		if (node instanceof Parent parent) {
+			for (Node child : parent.getChildrenUnmodifiable()) {
+				ComboBox<?> comboBox = findComboBox(child);
+				if (comboBox != null) {
+					return comboBox;
+				}
+			}
+		}
+		return null;
 	}
 
 


### PR DESCRIPTION
Fixes #128.

## The bug

An MRCAPrior starts out without a distribution, but `ScalarDistributionInputEditor` assumed there is always one to edit:

- `m_beastObject` is set to the distribution being edited, which is null for a new MRCAPrior
- the MRCAPrior branch calls `expandedInit` before checking whether there is anything to expand
- the overridden `addInputLabel` then dereferences `m_beastObject.getID()` and throws

`InputEditorFactory.addInputs` catches that and reports it as "Could not add entry for distr". The priors panel rebuilds its editors every time it is shown, which is why switching tabs brought the message back.

## Regression point

Introduced by 6202bd0 ("merge BeastFX3 back into beast3 #36"), which switched BEAUti's Add Prior action to the spec `MRCAPrior` (whose `distr` input is a `ScalarDistribution`) and added `ScalarDistributionInputEditor` for that type. The editor it replaced, `ParametricDistributionInputEditor`, kept the object owning the input in `m_beastObject` and skipped the expanded initialisation when the input had no value, so it did not have this problem. The failing path has been byte-identical since that commit -- the later commits touching the file are moves -- and the reproduction below fails at 4491b15 as well.

## The fix

- only take the MRCAPrior branch when there is a distribution to expand
- label the editor with the name of the input when there is no distribution to take the ID from, and add the pane holding it to the editor, so the combo box to select a distribution is shown at all (it was built but never displayed)
- collect the templates for that combo box from the object owning the input when there is no distribution to collect them from
- tolerate a null distribution in `formatName` and `getParameters`

The prior now shows as `Distr [selector]`, and picking a distribution works from there as well as from the row combo box.

## Tests

- `ScalarDistributionInputEditorTest.testEditorForMRCAPriorWithoutDistribution` -- builds the editor the way BEAUti does; without the fix it fails with the reported `NullPointerException`.
- `BeautiMRCAPriorTest` -- drives BEAUti through the steps from the issue (import an alignment, add an MRCA prior, switch tabs, pick a distribution) and fails on the popup without the fix.

The first commit is a separate test harness fix: TestFX clicks a point on the screen, and BEAUti windows are cascaded down as they are opened, so adding another BEAUti test class pushed the delete button in `LinkUnlinkTest.linkClocksDeleteAllTest` just below the bottom of the screen, where the click never reached it. Windows are now moved back onto the screen before clicking.

Full `beast-fx` suite: 25 tests, 0 failures.
