### PR TITLE
avoid hard cast to MCMC and support Runnable wrappers 

### DIFF
--- a/beast-fx/src/main/java/beastfx/app/beauti/BeautiTabPane.java
+++ b/beast-fx/src/main/java/beastfx/app/beauti/BeautiTabPane.java
@@ -1,23 +1,36 @@
 package beastfx.app.beauti;
 
 
-
-
-
-
+import beast.base.core.BEASTInterface;
+import beast.base.core.BEASTVersion2;
+import beast.base.core.Log;
+import beast.base.core.ProgramStatus;
+import beast.base.evolution.alignment.Alignment;
+import beast.base.parser.XMLParserException;
+import beast.base.spec.evolution.tree.MRCAPrior;
+import beast.pkgmgmt.BEASTClassLoader;
+import beast.pkgmgmt.PackageManager;
+import beast.pkgmgmt.Utils6;
+import beastfx.app.beauti.theme.Default;
+import beastfx.app.inputeditor.*;
+import beastfx.app.inputeditor.BeautiDoc.ActionOnExit;
+import beastfx.app.inputeditor.BeautiDoc.DOC_STATUS;
+import beastfx.app.methodsection.MethodsText;
+import beastfx.app.methodsection.Phrase;
+import beastfx.app.methodsection.XML2HTMLPaneFX;
+import beastfx.app.methodsection.XML2Text;
+import beastfx.app.tools.AppLauncher;
+import beastfx.app.util.Alert;
+import beastfx.app.util.FXUtils;
+import beastfx.app.util.Utils;
 import javafx.event.ActionEvent;
 import javafx.scene.Cursor;
 import javafx.scene.Scene;
-
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.CheckMenuItem;
+import javafx.scene.control.*;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
-import javafx.scene.control.RadioMenuItem;
-import javafx.scene.control.SeparatorMenuItem;
-import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
@@ -25,44 +38,10 @@ import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
-
 import org.xml.sax.SAXException;
 
-import beastfx.app.beauti.theme.Default;
-import beastfx.app.inputeditor.BEASTObjectDialog;
-import beastfx.app.inputeditor.BEASTObjectPanel;
-import beastfx.app.inputeditor.BeautiAlignmentProvider;
-import beastfx.app.inputeditor.BeautiConfig;
-import beastfx.app.inputeditor.BeautiDoc;
-import beastfx.app.inputeditor.BeautiDocListener;
-import beastfx.app.inputeditor.BeautiPanel;
-import beastfx.app.inputeditor.BeautiPanelConfig;
-import beastfx.app.inputeditor.MyAction;
-import beastfx.app.methodsection.MethodsText;
-import beastfx.app.methodsection.Phrase;
-import beastfx.app.methodsection.XML2HTMLPaneFX;
-import beastfx.app.methodsection.XML2Text;
-import beastfx.app.util.Alert;
-import beastfx.app.util.FXUtils;
-import beastfx.app.inputeditor.BeautiDoc.ActionOnExit;
-import beastfx.app.inputeditor.BeautiDoc.DOC_STATUS;
-import beastfx.app.tools.AppLauncher;
-import beastfx.app.util.Utils;
-import beast.base.core.BEASTInterface;
-import beast.base.core.BEASTVersion2;
-import beast.base.core.Log;
-import beast.base.core.ProgramStatus;
-import beast.base.evolution.alignment.Alignment;
-import beast.base.inference.MCMC;
-import beast.base.parser.XMLParserException;
-import beast.base.spec.evolution.tree.MRCAPrior;
-import beast.pkgmgmt.BEASTClassLoader;
-import beast.pkgmgmt.PackageManager;
-import beast.pkgmgmt.Utils6;
-
 import javax.xml.parsers.ParserConfigurationException;
-
-import java.awt.Toolkit;
+import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.ClipboardOwner;
 import java.awt.datatransfer.StringSelection;
@@ -75,6 +54,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.*;
+import java.util.List;
 
 
 public class BeautiTabPane extends beastfx.app.inputeditor.BeautiTabPane implements BeautiDocListener {
@@ -512,7 +492,9 @@ public class BeautiTabPane extends beastfx.app.inputeditor.BeautiTabPane impleme
 			XML2Text xml2text = new XML2Text(doc);
 			try {
 				MethodsText.initNameMap();
-				String text = xml2text.initialise((MCMC) doc.mcmc.get());
+				// doc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+				// ClassCastException on a plain (MCMC) doc.mcmc.get() cast.
+				String text = xml2text.initialise(doc.getMCMC());
 				List<Phrase> m = xml2text.getPhrases();
 				String html = XML2HTMLPaneFX.header + Phrase.toHTML(doc, m) + XML2HTMLPaneFX.footer + "</body>\n</html>";
 				WebView webView = new WebView();

--- a/beast-fx/src/main/java/beastfx/app/beauti/ClockModelListInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/beauti/ClockModelListInputEditor.java
@@ -1,18 +1,6 @@
 package beastfx.app.beauti;
 
 
-
-import java.util.ArrayList;
-import java.util.List;
-
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.TextField;
-import javafx.scene.control.Tooltip;
-import javafx.scene.layout.HBox;
-import beastfx.app.inputeditor.BeautiDoc;
-import beastfx.app.inputeditor.ListInputEditor;
-import beastfx.app.inputeditor.SmallLabel;
-import beastfx.app.util.FXUtils;
 import beast.base.core.BEASTInterface;
 import beast.base.core.Input;
 import beast.base.core.Log;
@@ -23,9 +11,17 @@ import beast.base.inference.Operator;
 import beast.base.inference.operator.DeltaExchangeOperator;
 import beast.base.inference.parameter.IntegerParameter;
 import beast.base.inference.parameter.RealParameter;
+import beastfx.app.inputeditor.BeautiDoc;
+import beastfx.app.inputeditor.ListInputEditor;
+import beastfx.app.inputeditor.SmallLabel;
+import beastfx.app.util.FXUtils;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.HBox;
 
-
-
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class ClockModelListInputEditor extends ListInputEditor {
@@ -56,18 +52,25 @@ public class ClockModelListInputEditor extends ListInputEditor {
     
     DeltaExchangeOperator operator;
     protected SmallLabel fixMeanRatesValidateLabel;
-    
+
+    private List<Operator> getOperators() {
+        MCMC mcmc = doc.getMCMC();
+        return mcmc == null ? new ArrayList<>() : mcmc.operatorsInput.get();
+    }
+
     @Override
     public void init(Input<?> input, BEASTInterface beastObject, int itemNr, ExpandOption isExpandOption, boolean addButtons) {
     	fixMeanRatesCheckBox = new CheckBox("Fix mean rate of clock models");
     	m_buttonStatus = ButtonStatus.NONE;
     	super.init(input, beastObject, itemNr, isExpandOption, addButtons);
     	
-		List<Operator> operators = ((MCMC) doc.mcmc.get()).operatorsInput.get();
+		// doc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+		// ClassCastException on a plain (MCMC) doc.mcmc.get() cast.
+		List<Operator> operators = getOperators();
     	fixMeanRatesCheckBox.setOnAction(e -> {
     		CheckBox averageRatesBox = (CheckBox) e.getSource();
 				boolean averageRates = averageRatesBox.isSelected();
-				List<Operator> operators2 = ((MCMC) doc.mcmc.get()).operatorsInput.get();
+				List<Operator> operators2 = getOperators();
 				if (averageRates) {
 					// connect DeltaExchangeOperator
 					if (!operators2.contains(operator)) {

--- a/beast-fx/src/main/java/beastfx/app/beauti/OperatorListInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/beauti/OperatorListInputEditor.java
@@ -20,6 +20,7 @@ import beastfx.app.inputeditor.ListInputEditor;
 import beastfx.app.util.FXUtils;
 import beast.base.core.BEASTInterface;
 import beast.base.core.Input;
+import beast.base.inference.MCMC;
 import beast.base.inference.Operator;
 import beast.base.inference.StateNode;
 
@@ -62,9 +63,15 @@ public class OperatorListInputEditor extends ListInputEditor {
     	m_buttonStatus = ButtonStatus.NONE;
     	super.init(input, beastObject, itemNr, isExpandOption, addButtons);
     	
-    	BEASTObjectInputEditor osEditor = new BEASTObjectInputEditor(doc);
-    	osEditor.init(((BEASTInterface) doc.mcmc.get()).getInput("operatorschedule"), (BEASTInterface) doc.mcmc.get(), -1, isExpandOption, addButtons);
-    	((BorderPane)pane).setBottom(osEditor);
+    	// the operator schedule lives on the MCMC, which for a wrapper Runnable like PathSampler
+    	// is the inner one -- doc.mcmc.get() itself has no "operatorschedule" input, and
+    	// getInput() would throw IllegalArgumentException rather than return null
+    	MCMC mcmc = doc.getMCMC();
+    	if (mcmc != null) {
+    		BEASTObjectInputEditor osEditor = new BEASTObjectInputEditor(doc);
+    		osEditor.init(mcmc.getInput("operatorschedule"), mcmc, -1, isExpandOption, addButtons);
+    		((BorderPane)pane).setBottom(osEditor);
+    	}
     }
     
     @Override

--- a/beast-fx/src/main/java/beastfx/app/beauti/StateNodeInitialiserListInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/beauti/StateNodeInitialiserListInputEditor.java
@@ -1,20 +1,6 @@
 package beastfx.app.beauti;
 
 
-
-import java.util.ArrayList;
-import java.util.List;
-
-import javafx.application.Platform;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.Label;
-import javafx.scene.layout.Pane;
-
-import beastfx.app.inputeditor.BeautiDoc;
-import beastfx.app.inputeditor.BeautiSubTemplate;
-import beastfx.app.inputeditor.InputEditor;
-import beastfx.app.inputeditor.ListInputEditor;
-import beastfx.app.util.FXUtils;
 import beast.base.core.BEASTInterface;
 import beast.base.core.Input;
 import beast.base.evolution.tree.Tree;
@@ -23,6 +9,18 @@ import beast.base.inference.State;
 import beast.base.inference.StateNode;
 import beast.base.inference.StateNodeInitialiser;
 import beast.base.parser.PartitionContext;
+import beastfx.app.inputeditor.BeautiDoc;
+import beastfx.app.inputeditor.BeautiSubTemplate;
+import beastfx.app.inputeditor.InputEditor;
+import beastfx.app.inputeditor.ListInputEditor;
+import beastfx.app.util.FXUtils;
+import javafx.application.Platform;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Pane;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class StateNodeInitialiserListInputEditor extends ListInputEditor {
 
@@ -128,8 +126,14 @@ public class StateNodeInitialiserListInputEditor extends ListInputEditor {
         // scrub Tree initialisers
     	
         // 0. collect state node info
-        List<StateNodeInitialiser> inits = ((MCMC)doc.mcmc.get()).initialisersInput.get();
-        State state = ((MCMC)doc.mcmc.get()).startStateInput.get();
+        // doc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+        // ClassCastException on a plain (MCMC) doc.mcmc.get() cast; nothing to scrub if there's no MCMC.
+        MCMC mcmc = doc.getMCMC();
+        if (mcmc == null) {
+            return false;
+        }
+        List<StateNodeInitialiser> inits = mcmc.initialisersInput.get();
+        State state = mcmc.startStateInput.get();
         List<StateNode> stateNodes = state.stateNodeInput.get();
         List<Tree> trees = new ArrayList<>();
         for (StateNode s: stateNodes) {

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/AlignmentListInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/AlignmentListInputEditor.java
@@ -1,14 +1,24 @@
 package beastfx.app.inputeditor;
 
 
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
+import beast.base.core.BEASTInterface;
+import beast.base.core.Input;
+import beast.base.core.Log;
+import beast.base.evolution.alignment.Alignment;
+import beast.base.evolution.alignment.FilteredAlignment;
+import beast.base.evolution.alignment.Taxon;
+import beast.base.evolution.branchratemodel.BranchRateModel;
+import beast.base.evolution.sitemodel.SiteModelInterface;
+import beast.base.evolution.tree.TreeInterface;
+import beast.base.inference.CompoundDistribution;
+import beast.base.inference.State;
+import beast.base.inference.StateNode;
+import beast.base.parser.PartitionContext;
+import beast.base.spec.evolution.likelihood.GenericTreeLikelihood;
+import beast.base.spec.evolution.sitemodel.SiteModel;
+import beastfx.app.util.Alert;
+import beastfx.app.util.FXUtils;
+import beastfx.app.util.PartitionContextUtil;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -19,20 +29,8 @@ import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.scene.Node;
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.Label;
-import javafx.scene.control.SelectionMode;
-import javafx.scene.control.TableCell;
-import javafx.scene.control.TableColumn;
+import javafx.scene.control.*;
 import javafx.scene.control.TableColumn.CellEditEvent;
-import javafx.scene.control.TableRow;
-import javafx.scene.control.TableView;
-import beastfx.app.util.Alert;
-import beastfx.app.util.FXUtils;
-import javafx.scene.control.TextField;
-import javafx.scene.control.Tooltip;
 import javafx.scene.control.cell.CheckBoxTableCell;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.cell.TextFieldTableCell;
@@ -43,23 +41,9 @@ import javafx.scene.input.TransferMode;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
-import beastfx.app.util.PartitionContextUtil;
-import beast.base.core.BEASTInterface;
-import beast.base.core.Input;
-import beast.base.core.Log;
-import beast.base.evolution.alignment.Alignment;
-import beast.base.evolution.alignment.FilteredAlignment;
-import beast.base.evolution.alignment.Taxon;
-import beast.base.evolution.branchratemodel.BranchRateModel;
-import beast.base.spec.evolution.likelihood.GenericTreeLikelihood;
-import beast.base.spec.evolution.sitemodel.SiteModel;
-import beast.base.evolution.sitemodel.SiteModelInterface;
-import beast.base.evolution.tree.TreeInterface;
-import beast.base.inference.CompoundDistribution;
-import beast.base.inference.MCMC;
-import beast.base.inference.State;
-import beast.base.inference.StateNode;
-import beast.base.parser.PartitionContext;
+
+import java.io.File;
+import java.util.*;
 
 // TODO: add warning if useAmbiguities=false and nr of patterns=1 (happens when all data is ambiguous)
 
@@ -416,8 +400,10 @@ public class AlignmentListInputEditor extends ListInputEditor {
 				if (siteModel != likelihoods[rowNr].siteModelInput.get()) {
 					PartitionContext context = getPartitionContext(rowNr);
 					try {
+					// doc.getMCMC() (not a plain (MCMC) doc.mcmc.get() cast) so this doesn't
+					// throw ClassCastException when a wrapper Runnable like PathSampler is active.
 					siteModel = (SiteModel.Base) BeautiDoc.deepCopyPlugin((BEASTInterface) likelihoods[rowNr].siteModelInput.get(),
-							likelihoods[rowNr], (MCMC) doc.mcmc.get(), oldContext, context, doc, null);
+							likelihoods[rowNr], doc.getMCMC(), oldContext, context, doc, null);
 					} catch (RuntimeException e) {
 						Alert.showMessageDialog(this, "Could not clone site model: " + e.getMessage());
 						return;
@@ -453,7 +439,7 @@ public class AlignmentListInputEditor extends ListInputEditor {
 					PartitionContext context = getPartitionContext(rowNr);
 					try {
 						clockModel = (BranchRateModel) BeautiDoc.deepCopyPlugin(likelihoods[rowNr].branchRateModelInput.get(),
-							likelihoods[rowNr], (MCMC) doc.mcmc.get(), oldContext, context, doc, null);
+							likelihoods[rowNr], doc.getMCMC(), oldContext, context, doc, null);
 					} catch (RuntimeException e) {
 						Alert.showMessageDialog(this, "Could not clone clock model: " + e.getMessage());
 						return;
@@ -492,20 +478,20 @@ public class AlignmentListInputEditor extends ListInputEditor {
 					PartitionContext context = getPartitionContext(rowNr);
 					try {
 						tree = (TreeInterface) BeautiDoc.deepCopyPlugin((BEASTInterface) likelihoods[rowNr].treeInput.get(), likelihoods[rowNr],
-							(MCMC) doc.mcmc.get(), oldContext, context, doc, null);
+							doc.getMCMC(), oldContext, context, doc, null);
 					} catch (RuntimeException e) {
 						Alert.showMessageDialog(this, "Could not clone tree model: " + e.getMessage());
 						return;
 					}
 					
-					State state = ((MCMC) doc.mcmc.get()).startStateInput.get();
+					State state = (doc.getMCMC()).startStateInput.get();
 					List<StateNode> stateNodes = new ArrayList<>();
 					stateNodes.addAll(state.stateNodeInput.get());
 					for (StateNode s : stateNodes) {
 						if (s.getID().endsWith(".t:" + oldContext.tree) && !(s instanceof TreeInterface)) {
 							try {
 								@SuppressWarnings("unused")
-								StateNode copy = (StateNode) BeautiDoc.deepCopyPlugin(s, likelihoods[rowNr], (MCMC) doc.mcmc.get(), oldContext, context, doc, null);
+								StateNode copy = (StateNode) BeautiDoc.deepCopyPlugin(s, likelihoods[rowNr], doc.getMCMC(), oldContext, context, doc, null);
 							} catch (RuntimeException e) {
 								Alert.showMessageDialog(this, "Could not clone tree model: " + e.getMessage());
 								return;

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiConnector.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiConnector.java
@@ -1,20 +1,16 @@
 package beastfx.app.inputeditor;
 
 
-import java.lang.reflect.Method;
-import java.util.List;
-
-import beast.base.core.BEASTInterface;
-import beast.base.core.BEASTObject;
-import beast.base.core.Description;
-import beast.base.core.Input;
+import beast.base.core.*;
 import beast.base.core.Input.Validate;
-import beast.base.core.Log;
 import beast.base.inference.MCMC;
 import beast.base.inference.Operator;
 import beast.base.parser.PartitionContext;
 import beast.pkgmgmt.BEASTClassLoader;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Description("Specifies which part of the template get connected to the main network")
@@ -199,7 +195,10 @@ public class BeautiConnector extends BEASTObject {
                         break;
                     //System.err.println("isActivated::is in posterior");
                     case IS_NOT_AN_OPERTOR:
-        				List<Operator> operators = ((MCMC) doc.mcmc.get()).operatorsInput.get();
+        				// doc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of
+        				// throwing ClassCastException on a plain (MCMC) doc.mcmc.get() cast.
+        				MCMC mcmc = doc.getMCMC();
+        				List<Operator> operators = mcmc == null ? new ArrayList<>() : mcmc.operatorsInput.get();
         				if (operators.contains(beastObject)) {
         					return false;
         				}

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
@@ -1,87 +1,13 @@
 package beastfx.app.inputeditor;
 
 
-
-
-
-
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintStream;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.lang.module.ModuleReader;
-import java.lang.module.ResolvedModule;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import beastfx.app.util.Alert;
-import beastfx.app.util.FXUtils;
-import javafx.scene.control.ButtonType;
-import javafx.stage.Stage;
-
-import javax.swing.JOptionPane;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-
-import beastfx.app.beauti.BeautiTabPane;
-import beastfx.app.util.PartitionContextUtil;
-import beast.base.core.BEASTInterface;
-import beast.base.core.BEASTObject;
-import beast.base.core.Description;
-import beast.base.core.Input;
-import beast.base.core.Log;
+import beast.base.core.*;
 import beast.base.core.Input.Validate;
 import beast.base.evolution.alignment.Alignment;
 import beast.base.evolution.alignment.FilteredAlignment;
 import beast.base.evolution.alignment.Taxon;
 import beast.base.evolution.alignment.TaxonSet;
 import beast.base.evolution.branchratemodel.BranchRateModel;
-import beast.base.spec.evolution.branchratemodel.Base;
-import beast.base.spec.evolution.branchratemodel.StrictClockModel;
-import beast.base.spec.evolution.likelihood.GenericTreeLikelihood;
-import beast.base.spec.evolution.tree.MRCAPrior;
-import beast.base.spec.inference.distribution.Normal;
-import beast.base.spec.inference.distribution.ScalarDistribution;
-import beast.base.spec.inference.parameter.RealScalarParam;
-import beast.base.spec.inference.parameter.RealVectorParam;
 import beast.base.evolution.operator.TipDatesRandomWalker;
 import beast.base.evolution.substitutionmodel.SubstitutionModel;
 import beast.base.evolution.tree.TraitSet;
@@ -93,17 +19,50 @@ import beast.base.inference.MCMC;
 import beast.base.inference.StateNode;
 import beast.base.inference.distribution.Prior;
 import beast.base.inference.parameter.Parameter;
-//import beast.base.inference.parameter.RealParameter;
-import beast.base.parser.JSONProducer;
-import beast.base.parser.NexusParser;
-import beast.base.parser.PartitionContext;
-import beast.base.parser.XMLParser;
-import beast.base.parser.XMLParserException;
-import beast.base.parser.XMLProducer;
+import beast.base.parser.*;
 import beast.base.parser.XMLParser.RequiredInputProvider;
+import beast.base.spec.evolution.branchratemodel.Base;
+import beast.base.spec.evolution.branchratemodel.StrictClockModel;
+import beast.base.spec.evolution.likelihood.GenericTreeLikelihood;
+import beast.base.spec.evolution.tree.MRCAPrior;
+import beast.base.spec.inference.distribution.Normal;
+import beast.base.spec.inference.distribution.ScalarDistribution;
+import beast.base.spec.inference.parameter.RealScalarParam;
+import beast.base.spec.inference.parameter.RealVectorParam;
 import beast.pkgmgmt.BEASTClassLoader;
 import beast.pkgmgmt.PackageManager;
 import beast.pkgmgmt.launcher.BeastLauncher;
+import beastfx.app.beauti.BeautiTabPane;
+import beastfx.app.util.Alert;
+import beastfx.app.util.FXUtils;
+import beastfx.app.util.PartitionContextUtil;
+import javafx.scene.control.ButtonType;
+import javafx.stage.Stage;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.*;
+import java.lang.module.ModuleReader;
+import java.lang.module.ResolvedModule;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+//import beast.base.inference.parameter.RealParameter;
 
 
 @Description("Beauti document in doc-view pattern, not useful in models")
@@ -123,6 +82,26 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
 
     final public Input<beast.base.inference.Runnable> mcmc = new Input<>("runnable", "main entry of analysis",
             Validate.REQUIRED);
+
+    /** mcmc.get() is usually an MCMC, but a Runnable such as a path-sampling/stepping-stone
+     *  driver can wrap its own MCMC as an input named "mcmc" instead of extending MCMC directly
+     *  (see modelselection.inference.PathSampler). Use this instead of hard-casting mcmc.get()
+     *  to MCMC, so picking such a Runnable in the MCMC panel doesn't crash BEAUti with a
+     *  ClassCastException. Returns null if no MCMC can be found either way. */
+    public MCMC getMCMC() {
+        return getMCMC(mcmc.get());
+    }
+
+    /** Same unwrap as {@link #getMCMC()}, for a Runnable obtained from somewhere other than
+     *  this doc's own mcmc input -- e.g. a freshly parsed XML file (parser.parseFile(...) also
+     *  returns a plain Runnable, not necessarily an MCMC). */
+    public static MCMC getMCMC(beast.base.inference.Runnable runnable) {
+        if (runnable instanceof MCMC) {
+            return (MCMC) runnable;
+        }
+        Object inner = runnable == null ? null : runnable.getInputValue("mcmc");
+        return (inner instanceof MCMC) ? (MCMC) inner : null;
+    }
 
     public List<BranchRateModel> clockModels;
     // protected List<TreeDistribution> treePriors;
@@ -1608,7 +1587,9 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
                 // so we need to check that the model changed, and if so,
                 // revisit the BeautiConnectors
                 List<BEASTInterface> posteriorPredecessors2 = new ArrayList<>();
-                collectPredecessors(((MCMC) mcmc.get()).posteriorInput.get(), posteriorPredecessors2);
+                // getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+                // ClassCastException on a plain (MCMC) mcmc.get() cast.
+                collectPredecessors(getMCMC().posteriorInput.get(), posteriorPredecessors2);
                 if (posteriorPredecessors.size() != posteriorPredecessors2.size()) {
                     progress = true;
                 } else {
@@ -1652,7 +1633,9 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
 
     public void setUpActivePlugins() {
         posteriorPredecessors = new ArrayList<>();
-        collectPredecessors(((MCMC) mcmc.get()).posteriorInput.get(), posteriorPredecessors);
+        // getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+        // ClassCastException on a plain (MCMC) mcmc.get() cast.
+        collectPredecessors(getMCMC().posteriorInput.get(), posteriorPredecessors);
         likelihoodPredecessors = new ArrayList<>();
         if (pluginmap.containsKey("likelihood")) {
             collectPredecessors(pluginmap.get("likelihood"), likelihoodPredecessors);
@@ -1877,6 +1860,18 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
             if (target == null) {
                 Log.trace.println("BeautiDoc: Could not find object " + targetID);
                 return;
+            }
+            // A wrapper Runnable such as a path-sampling/stepping-stone driver (see
+            // modelselection.inference.PathSampler) does not itself have MCMC's usual inputs
+            // (logger, operator, state, ...) -- it holds its own MCMC via an input named "mcmc"
+            // instead of extending MCMC directly. If the target lacks the requested input but has
+            // one named "mcmc", retry against that inner MCMC so <connect targetID='mcmc' .../>
+            // rules written for a plain MCMC still work when such a wrapper is the active runnable.
+            if (!target.getInputs().containsKey(inputName) && target.getInputs().containsKey("mcmc")) {
+                Object inner = target.getInputValue("mcmc");
+                if (inner instanceof BEASTInterface && ((BEASTInterface) inner).getInputs().containsKey(inputName)) {
+                    target = (BEASTInterface) inner;
+                }
             }
             // prevent duplication inserts in list
             Object o = target.getInputValue(inputName);
@@ -2856,7 +2851,9 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
     public BEASTInterface getUnlinkCandidate(Input<?> input, BEASTInterface parent) {
         PartitionContext oldContext = getContextFor((BEASTInterface)input.get());
         PartitionContext newContext = getContextFor(parent);
-        BEASTInterface beastObject = deepCopyPlugin((BEASTInterface) input.get(), parent, (MCMC) mcmc.get(), oldContext, newContext, this, null);
+        // getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+        // ClassCastException on a plain (MCMC) mcmc.get() cast.
+        BEASTInterface beastObject = deepCopyPlugin((BEASTInterface) input.get(), parent, getMCMC(), oldContext, newContext, this, null);
         return beastObject;
     }
 
@@ -2971,7 +2968,9 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
                 t.initAndValidate();
                 operator.initByName("taxonset", t, "weight", 1.0, "tree", tree, "windowSize", 1.0);
                 operator.setID("TipDatesRandomWalker." + t.getID());
-                MCMC mcmc = (MCMC) this.mcmc.get();
+                // getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+                // ClassCastException on a plain (MCMC) mcmc.get() cast.
+                MCMC mcmc = getMCMC();
                 mcmc.operatorsInput.setValue(operator, mcmc);
             }
             // set up date trait

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
@@ -1857,6 +1857,27 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
     }
 
 
+    /**
+     * A wrapper Runnable such as a path-sampling/stepping-stone driver (see
+     * modelselection.inference.PathSampler) does not itself have MCMC's usual inputs
+     * (logger, operator, state, ...) -- it holds its own MCMC via an input named "mcmc"
+     * instead of extending MCMC directly. If the target lacks the requested input but has
+     * one named "mcmc", redirect to that inner MCMC so <connect targetID='mcmc' .../> rules
+     * written for a plain MCMC still work when such a wrapper is the active runnable.
+     * Must be used by both connect() and disconnect(), otherwise objects can be connected
+     * to the inner MCMC but never removed from it again.
+     */
+    private BEASTInterface redirectToInnerMCMC(BEASTInterface target, String inputName) {
+        if (target != null && !target.getInputs().containsKey(inputName) && target.getInputs().containsKey("mcmc")) {
+            Object inner = target.getInputValue("mcmc");
+            if (inner instanceof BEASTInterface && ((BEASTInterface) inner).getInputs().containsKey(inputName)) {
+                return (BEASTInterface) inner;
+            }
+        }
+        return target;
+    }
+
+
     public void connect(BEASTInterface srcBEASTObject, String targetID, String inputName) {
         try {
             BEASTInterface target = pluginmap.get(targetID);
@@ -1864,18 +1885,7 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
                 Log.trace.println("BeautiDoc: Could not find object " + targetID);
                 return;
             }
-            // A wrapper Runnable such as a path-sampling/stepping-stone driver (see
-            // modelselection.inference.PathSampler) does not itself have MCMC's usual inputs
-            // (logger, operator, state, ...) -- it holds its own MCMC via an input named "mcmc"
-            // instead of extending MCMC directly. If the target lacks the requested input but has
-            // one named "mcmc", retry against that inner MCMC so <connect targetID='mcmc' .../>
-            // rules written for a plain MCMC still work when such a wrapper is the active runnable.
-            if (!target.getInputs().containsKey(inputName) && target.getInputs().containsKey("mcmc")) {
-                Object inner = target.getInputValue("mcmc");
-                if (inner instanceof BEASTInterface && ((BEASTInterface) inner).getInputs().containsKey(inputName)) {
-                    target = (BEASTInterface) inner;
-                }
-            }
+            target = redirectToInnerMCMC(target, inputName);
             // prevent duplication inserts in list
             Object o = target.getInputValue(inputName);
             if (o instanceof List) {
@@ -1901,6 +1911,11 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
         }
         BEASTInterface srcBEASTObject = pluginmap.get(translatePartitionNames(connector.sourceID, context));
         String targetID = translatePartitionNames(connector.targetID, context);
+        // same targetID translation as connect(BeautiConnector, PartitionContext) does, so that
+        // <connect targetID='mcmc' .../> resolves for a runnable whose ID is not literally "mcmc"
+    	if (targetID.equals("mcmc")) {
+    		targetID = mcmc.get().getID();
+    	}
         disconnect(srcBEASTObject, targetID, connector.targetInput);
     }
 
@@ -1910,6 +1925,7 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
             if (target == null) {
                 return;
             }
+            target = redirectToInnerMCMC(target, inputName);
             final Input<?> input = target.getInput(inputName);
             Object o = input.get();
             if (o instanceof List) {

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
@@ -96,11 +96,14 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
      *  this doc's own mcmc input -- e.g. a freshly parsed XML file (parser.parseFile(...) also
      *  returns a plain Runnable, not necessarily an MCMC). */
     public static MCMC getMCMC(beast.base.inference.Runnable runnable) {
-        if (runnable instanceof MCMC) {
-            return (MCMC) runnable;
+        if (runnable instanceof MCMC mcmc) {
+            return mcmc;
         }
-        Object inner = runnable == null ? null : runnable.getInputValue("mcmc");
-        return (inner instanceof MCMC) ? (MCMC) inner : null;
+        // getInputValue("mcmc") would throw IllegalArgumentException if "mcmc" is not a
+        // registered input name, so check containsKey first rather than relying on a catch.
+        Object inner = (runnable != null && runnable.getInputs().containsKey("mcmc"))
+                ? runnable.getInputValue("mcmc") : null;
+        return (inner instanceof MCMC mcmc) ? mcmc : null;
     }
 
     public List<BranchRateModel> clockModels;

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiPanel.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiPanel.java
@@ -1,18 +1,16 @@
 package beastfx.app.inputeditor;
 
 
-
 import beast.base.core.BEASTInterface;
 import beast.base.core.Input;
 import beast.base.evolution.alignment.Taxon;
 import beast.base.evolution.branchratemodel.BranchRateModel;
-import beast.base.spec.evolution.likelihood.GenericTreeLikelihood;
-import beast.base.spec.evolution.sitemodel.SiteModel;
 import beast.base.evolution.sitemodel.SiteModelInterface;
 import beast.base.evolution.tree.TreeInterface;
 import beast.base.inference.CompoundDistribution;
-import beast.base.inference.MCMC;
 import beast.base.parser.PartitionContext;
+import beast.base.spec.evolution.likelihood.GenericTreeLikelihood;
+import beast.base.spec.evolution.sitemodel.SiteModel;
 import beastfx.app.beauti.ClonePartitionPanel;
 import beastfx.app.inputeditor.BeautiPanelConfig.Partition;
 import beastfx.app.inputeditor.InputEditor.ExpandOption;
@@ -425,8 +423,10 @@ public class BeautiPanel extends Tab implements ChangeListener, BeautiDocProvide
 			SiteModelInterface siteModelSource = likelihoodSource.siteModelInput.get();
 			SiteModelInterface  siteModel = null;
 			try {
+				// doc.getMCMC() (not a plain (MCMC) doc.mcmc.get() cast) so this doesn't
+				// throw ClassCastException when a wrapper Runnable like PathSampler is active.
 				siteModel = (SiteModel.Base) BeautiDoc.deepCopyPlugin((BEASTInterface) siteModelSource,
-					likelihood, (MCMC) doc.mcmc.get(), oldContext, newContext, doc, null);
+					likelihood, doc.getMCMC(), oldContext, newContext, doc, null);
 			} catch (RuntimeException e) {
 				Alert.showMessageDialog(this.getContent() instanceof Pane ? ((Pane)this.getContent()) : null, 
 						"Could not clone " + sourceID + " to " + targetID + " " + e.getMessage());
@@ -439,7 +439,7 @@ public class BeautiPanel extends Tab implements ChangeListener, BeautiDocProvide
     		BranchRateModel clockModel = null;
 			try {
 				clockModel = (BranchRateModel) BeautiDoc.deepCopyPlugin((BEASTInterface) clockModelSource,
-						likelihood, (MCMC) doc.mcmc.get(), oldContext, newContext, doc, null);
+						likelihood, doc.getMCMC(), oldContext, newContext, doc, null);
 			} catch (Exception e) {
 				Alert.showMessageDialog(this.getContent() instanceof Pane ? ((Pane)this.getContent()) : null, 
 						"Could not clone " + sourceID + " to " + targetID + " " + e.getMessage());
@@ -472,7 +472,7 @@ public class BeautiPanel extends Tab implements ChangeListener, BeautiDocProvide
 			TreeInterface treeSource = likelihoodSource.treeInput.get();
 			try {
 			tree = (TreeInterface) BeautiDoc.deepCopyPlugin((BEASTInterface) treeSource, likelihood,
-							(MCMC) doc.mcmc.get(), oldContext, newContext, doc, null);
+							doc.getMCMC(), oldContext, newContext, doc, null);
 				} catch (Exception e) {
 					Alert.showMessageDialog(((Pane)this.getContent()), "Could not clone " + sourceID + " to " + targetID + " " + e.getMessage());
 					return;

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiPanelConfig.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiPanelConfig.java
@@ -1,20 +1,13 @@
 package beastfx.app.inputeditor;
 
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import beastfx.app.inputeditor.BEASTObjectPanel;
-import beast.base.core.BEASTInterface;
-import beast.base.core.BEASTObject;
-import beast.base.core.Description;
-import beast.base.core.Input;
-import beast.base.core.Log;
+import beast.base.core.*;
 import beast.base.core.Input.Validate;
 import beast.pkgmgmt.BEASTClassLoader;
 
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 
 @Description("Defines properties for custom panels in Beauti")
@@ -172,6 +165,19 @@ public class BeautiPanelConfig extends BEASTObject {
                 parentBEASTObjects = new ArrayList<>();
                 parentInputs = new ArrayList<>();
                 for (BEASTInterface beastObject : oldPlugins) {
+                    // A wrapper Runnable such as a path-sampling/stepping-stone driver (see
+                    // modelselection.inference.PathSampler) does not itself have MCMC's usual
+                    // inputs (distribution, operator, tree, siteModel, ...) -- it holds its own
+                    // MCMC via an input named "mcmc" instead of extending MCMC directly. Fall
+                    // back to that inner MCMC so panels configured against a plain MCMC
+                    // (Partitions, Priors, Operators, ...) still resolve when such a wrapper is
+                    // the active runnable, instead of throwing and leaving the panel empty.
+                    if (!beastObject.getInputs().containsKey(pathComponents[i]) && beastObject.getInputs().containsKey("mcmc")) {
+                        Object inner = beastObject.getInputValue("mcmc");
+                        if (inner instanceof BEASTInterface && ((BEASTInterface) inner).getInputs().containsKey(pathComponents[i])) {
+                            beastObject = (BEASTInterface) inner;
+                        }
+                    }
                     final Input<?> namedInput = beastObject.getInput(pathComponents[i]);
                     type = namedInput.getType();
                     if (namedInput.get() instanceof List<?>) {

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/MRCAPriorInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/MRCAPriorInputEditor.java
@@ -32,6 +32,7 @@ import beast.base.spec.inference.parameter.RealScalarParam;
 import beast.base.evolution.tree.Tree;
 import beast.base.inference.CompoundDistribution;
 import beast.base.inference.Distribution;
+import beast.base.inference.MCMC;
 import beast.base.inference.Operator;
 import beast.base.inference.State;
 import beast.base.parser.PartitionContext;
@@ -325,8 +326,14 @@ public class MRCAPriorInputEditor extends InputEditor.Base implements HasExpandB
     		operator.initByName("tree", prior.treeInput.get(), "taxonset", taxonset, "windowSize", 1.0, "weight", 1.0);
     	}
    		operator.setID("tipDatesSampler." + taxonset.getID());
-   	    	
-    	doc.mcmc.get().setInputValue("operator", operator);
+
+   		// the operator list lives on the MCMC, which for a wrapper Runnable like PathSampler is
+   		// the inner one -- doc.mcmc.get() itself has no "operator" input, and setInputValue()
+   		// would throw IllegalArgumentException
+   		MCMC mcmc = doc.getMCMC();
+   		if (mcmc != null) {
+   			mcmc.setInputValue("operator", operator);
+   		}
 	}
 
     // remove TipDatesRandomWalker from list of operators
@@ -350,8 +357,12 @@ public class MRCAPriorInputEditor extends InputEditor.Base implements HasExpandB
     		return;
     	}
     	
-    	// remove from list of operators
-    	Object o = doc.mcmc.get().getInput("operator");
+    	// remove from list of operators -- see enableTipSampling() on why this goes via getMCMC()
+    	MCMC mcmc = doc.getMCMC();
+    	if (mcmc == null) {
+    		return;
+    	}
+    	Object o = mcmc.getInput("operator");
     	if (o instanceof Input<?>) {
     		Input<List<Operator>> operatorInput = (Input<List<Operator>>) o;
     		List<Operator> operators = operatorInput.get();

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/SiteModelInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/SiteModelInputEditor.java
@@ -1,16 +1,16 @@
 package beastfx.app.inputeditor;
 
 
-
-
-
 import beast.base.core.BEASTInterface;
 import beast.base.core.Input;
 import beast.base.evolution.alignment.Alignment;
 import beast.base.evolution.likelihood.GenericTreeLikelihood;
 import beast.base.evolution.sitemodel.SiteModel;
 import beast.base.evolution.sitemodel.SiteModelInterface;
-import beast.base.inference.*;
+import beast.base.inference.CompoundDistribution;
+import beast.base.inference.Distribution;
+import beast.base.inference.MCMC;
+import beast.base.inference.Operator;
 import beast.base.inference.operator.kernel.BactrianDeltaExchangeOperator;
 import beast.base.inference.parameter.IntegerParameter;
 import beast.base.inference.parameter.RealParameter;
@@ -58,7 +58,8 @@ public class SiteModelInputEditor extends BEASTObjectInputEditor {
     	fixMeanRatesCheckBox.setDisable(doc.autoUpdateFixMeanSubstRate);
     	super.init(input, beastObject, itemNr, isExpandOption, addButtons);
 
-		List<Operator> operators = ((MCMC) doc.mcmc.get()).operatorsInput.get();
+		MCMC mcmc = doc.getMCMC();
+		List<Operator> operators = mcmc == null ? new ArrayList<>() : mcmc.operatorsInput.get();
     	fixMeanRatesCheckBox.setOnAction(e -> {
     			CheckBox averageRatesBox = (CheckBox) e.getSource();
 				doFixMeanRates(averageRatesBox.isSelected());
@@ -124,7 +125,8 @@ public class SiteModelInputEditor extends BEASTObjectInputEditor {
 //    }
 
 	private void doFixMeanRates(boolean averageRates) {
-		List<Operator> operators = ((MCMC) doc.mcmc.get()).operatorsInput.get();
+		MCMC mcmc = doc.getMCMC();
+		List<Operator> operators = mcmc == null ? new ArrayList<>() : mcmc.operatorsInput.get();
 		if (averageRates) {
 			// connect DeltaExchangeOperator
 			if (!operators.contains(operator)) {

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/spec/SiteModelInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/spec/SiteModelInputEditor.java
@@ -1,24 +1,19 @@
 package beastfx.app.inputeditor.spec;
 
 
-
-
-
-
-
 import beast.base.core.BEASTInterface;
 import beast.base.core.Input;
 import beast.base.evolution.alignment.Alignment;
-import beast.base.spec.evolution.likelihood.GenericTreeLikelihood;
-import beast.base.spec.evolution.sitemodel.SiteModel;
 import beast.base.evolution.sitemodel.SiteModelInterface;
 import beast.base.inference.*;
 import beast.base.spec.domain.NonNegativeReal;
 import beast.base.spec.domain.PositiveInt;
+import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.evolution.likelihood.GenericTreeLikelihood;
+import beast.base.spec.evolution.sitemodel.SiteModel;
 import beast.base.spec.inference.operator.DeltaExchangeOperator;
 import beast.base.spec.inference.parameter.IntVectorParam;
 import beast.base.spec.inference.parameter.RealScalarParam;
-import beast.base.spec.domain.PositiveReal;
 import beast.base.spec.type.RealScalar;
 import beast.base.spec.type.Tensor;
 import beastfx.app.inputeditor.*;
@@ -66,7 +61,7 @@ public class SiteModelInputEditor extends BEASTObjectInputEditor {
     	fixMeanRatesCheckBox.setDisable(doc.autoUpdateFixMeanSubstRate);
     	super.init(input, beastObject, itemNr, isExpandOption, addButtons);
 
-		List<Operator> operators = ((MCMC) doc.mcmc.get()).operatorsInput.get();
+		List<Operator> operators = getOperators();
     	fixMeanRatesCheckBox.setOnAction(e -> {
     			CheckBox averageRatesBox = (CheckBox) e.getSource();
 				doFixMeanRates(averageRatesBox.isSelected());
@@ -125,8 +120,13 @@ public class SiteModelInputEditor extends BEASTObjectInputEditor {
 		setUpOperator();
     }
     
+	private List<Operator> getOperators() {
+		MCMC mcmc = doc.getMCMC();
+		return mcmc == null ? new ArrayList<>() : mcmc.operatorsInput.get();
+	}
+
 	private void doFixMeanRates(boolean averageRates) {
-		List<Operator> operators = ((MCMC) doc.mcmc.get()).operatorsInput.get();
+		List<Operator> operators = getOperators();
 		if (averageRates) {
 			// connect DeltaExchangeOperator
 			if (!operators.contains(operator)) {

--- a/beast-fx/src/main/java/beastfx/app/methodsection/XML2HTMLPane.java
+++ b/beast-fx/src/main/java/beastfx/app/methodsection/XML2HTMLPane.java
@@ -1,11 +1,29 @@
 package beastfx.app.methodsection;
 
 
-import static javafx.concurrent.Worker.State.FAILED;
+import beast.base.core.BEASTInterface;
+import beast.base.inference.MCMC;
+import beast.base.parser.XMLParser;
+import beastfx.app.inputeditor.BeautiConfig;
+import beastfx.app.inputeditor.BeautiDoc;
+import beastfx.app.methodsection.implementation.BEASTObjectMethodsText;
+import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.concurrent.Worker;
+import javafx.concurrent.Worker.State;
+import javafx.embed.swing.JFXPanel;
+import javafx.event.EventHandler;
+import javafx.scene.Scene;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebEvent;
+import javafx.scene.web.WebView;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.events.EventListener;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.Toolkit;
+import javax.swing.*;
+import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
@@ -18,34 +36,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 
-import javafx.application.*;
-import javafx.beans.value.*;
-import javafx.concurrent.*;
-import javafx.concurrent.Worker.State;
-import javafx.embed.swing.JFXPanel;
-import javafx.event.EventHandler;
-import javafx.scene.*;
-import javafx.scene.web.*;
-
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
-
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.events.EventListener;
-
-import beast.base.core.BEASTInterface;
-import beast.base.inference.MCMC;
-import beast.base.parser.XMLParser;
-import beastfx.app.inputeditor.BeautiConfig;
-import beastfx.app.inputeditor.BeautiDoc;
-import beastfx.app.methodsection.implementation.BEASTObjectMethodsText;
-
+import static javafx.concurrent.Worker.State.FAILED;
 
 
 public class XML2HTMLPane extends JPanel {
@@ -93,16 +84,19 @@ public class XML2HTMLPane extends JPanel {
 		}
 		
 		XMLParser parser = new XMLParser();
-		MCMC mcmc = (MCMC) parser.parseFile(file);
-		beautiDoc.mcmc.setValue(mcmc, beautiDoc);
+		// keep whatever the file's top-level Runnable actually is (MCMC, or a driver like
+		// PathSampler that wraps one) rather than pre-unwrapping it away; beautiDoc.getMCMC()
+		// unwraps it on demand instead of hard-casting straight to MCMC.
+		beast.base.inference.Runnable runnable = parser.parseFile(file);
+		beautiDoc.mcmc.setValue(runnable, beautiDoc);
 		for (BEASTInterface o : InputFilter.getDocumentObjects(beautiDoc.mcmc.get())) {
 			beautiDoc.registerPlugin(o);
 		}
 		beautiDoc.determinePartitions();
 		BEASTObjectMethodsText.setBeautiCFG(beautiDoc.beautiConfig);
-		
+
 		MethodsText.initNameMap();
-		initialise((MCMC) beautiDoc.mcmc.get(), true);		
+		initialise(beautiDoc.getMCMC(), true);
 	}
 	
 	final static String header = "<!DOCTYPE html>\n" +
@@ -118,7 +112,9 @@ public class XML2HTMLPane extends JPanel {
 	
 	public void initialise(MCMC mcmc, boolean update) throws Exception {		
 		xml2textProducer = new XML2Text(beautiDoc);
-		xml2textProducer.initialise((MCMC) beautiDoc.mcmc.get());
+		// beautiDoc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+		// ClassCastException on a plain (MCMC) beautiDoc.mcmc.get() cast.
+		xml2textProducer.initialise(beautiDoc.getMCMC());
 		m = xml2textProducer.getPhrases();
 		
 		html = header + Phrase.toHTML(beautiDoc, m) + "</body>\n</html>";
@@ -397,7 +393,9 @@ public class XML2HTMLPane extends JPanel {
 	public String getText(CitationPhrase.mode mode) throws Exception {		
 		CitationPhrase.CitationMode = mode;
 		xml2textProducer = new XML2Text(beautiDoc);
-		xml2textProducer.initialise((MCMC) beautiDoc.mcmc.get());
+		// beautiDoc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+		// ClassCastException on a plain (MCMC) beautiDoc.mcmc.get() cast.
+		xml2textProducer.initialise(beautiDoc.getMCMC());
 		m = xml2textProducer.getPhrases();
 		return Phrase.toString(m);
 	}

--- a/beast-fx/src/main/java/beastfx/app/methodsection/XML2HTMLPaneFX.java
+++ b/beast-fx/src/main/java/beastfx/app/methodsection/XML2HTMLPaneFX.java
@@ -1,58 +1,16 @@
 package beastfx.app.methodsection;
 
 
-
-import static javafx.concurrent.Worker.State.FAILED;
-
-import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.StringSelection;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.TreeMap;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import javafx.application.*;
-import javafx.beans.value.*;
-import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
-import javafx.scene.*;
-import javafx.scene.control.Alert;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.CheckMenuItem;
-import javafx.scene.control.Alert.AlertType;
-import javafx.scene.control.ChoiceDialog;
-import javafx.scene.control.CustomMenuItem;
-import javafx.scene.control.Menu;
-import javafx.scene.control.MenuBar;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.SeparatorMenuItem;
-import javafx.scene.control.TextArea;
-import javafx.scene.control.Tooltip;
-import javafx.scene.input.KeyCombination;
-import javafx.scene.input.KeyEvent;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.web.*;
-import javafx.stage.FileChooser;
-import javafx.stage.Stage;
-
-import netscape.javascript.JSObject;
-import javafx.concurrent.Worker.State;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
-
+import beast.base.core.BEASTInterface;
+import beast.base.core.Log;
+import beast.base.evolution.alignment.Alignment;
+import beast.base.inference.MCMC;
+import beast.base.parser.XMLParser;
+import beast.base.parser.XMLParserException;
+import beast.base.parser.XMLProducer;
+import beast.base.spec.evolution.tree.MRCAPrior;
+import beast.pkgmgmt.Package;
+import beast.pkgmgmt.PackageManager;
 import beastfx.app.beauti.BeautiTabPane;
 import beastfx.app.inputeditor.BeautiAlignmentProvider;
 import beastfx.app.inputeditor.BeautiConfig;
@@ -60,16 +18,46 @@ import beastfx.app.inputeditor.BeautiDoc;
 import beastfx.app.inputeditor.BeautiDoc.DOC_STATUS;
 import beastfx.app.methodsection.implementation.BEASTObjectMethodsText;
 import beastfx.app.util.Utils;
-import beast.base.core.BEASTInterface;
-import beast.base.inference.MCMC;
-import beast.base.core.Log;
-import beast.base.evolution.alignment.Alignment;
-import beast.base.spec.evolution.tree.MRCAPrior;
-import beast.pkgmgmt.Package;
-import beast.pkgmgmt.PackageManager;
-import beast.base.parser.XMLParser;
-import beast.base.parser.XMLParserException;
-import beast.base.parser.XMLProducer;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.concurrent.Worker.State;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.Scene;
+import javafx.scene.control.*;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.FileChooser;
+import javafx.stage.Stage;
+import netscape.javascript.JSObject;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+import java.util.List;
+
+import static javafx.concurrent.Worker.State.FAILED;
 
 
 public class XML2HTMLPaneFX extends Application {
@@ -95,7 +83,7 @@ public class XML2HTMLPaneFX extends Application {
 	}
 
 	public void processArgs(String [] args) throws Exception {
-		MCMC mcmc = null;
+		beast.base.inference.Runnable runnable = null;
 		if (args.length > 0) {
 			File file = new File(args[0]);
 			beautiDoc.setFileName(file.getAbsolutePath());
@@ -120,13 +108,16 @@ public class XML2HTMLPaneFX extends Application {
 			
 			
 			XMLParser parser = new XMLParser();
-			mcmc = (MCMC) parser.parseFile(file);
+			runnable = parser.parseFile(file);
 			this.file = file;
 		} else {
-			mcmc = (MCMC) beautiDoc.mcmc.get();
+			runnable = beautiDoc.mcmc.get();
 		}
 
-		beautiDoc.mcmc.setValue(mcmc, beautiDoc);
+		// keep whatever the top-level Runnable actually is (MCMC, or a driver like PathSampler
+		// that wraps one) rather than pre-unwrapping it away; beautiDoc.getMCMC() below unwraps
+		// it on demand instead of hard-casting straight to MCMC.
+		beautiDoc.mcmc.setValue(runnable, beautiDoc);
 		for (BEASTInterface o : InputFilter.getDocumentObjects(beautiDoc.mcmc.get())) {
 			if (o != null) {
 				beautiDoc.registerPlugin(o);
@@ -134,9 +125,9 @@ public class XML2HTMLPaneFX extends Application {
 		}
 		beautiDoc.determinePartitions();
 		BEASTObjectMethodsText.setBeautiCFG(beautiDoc.beautiConfig);
-		
+
 		MethodsText.initNameMap();
-		initialise((MCMC) beautiDoc.mcmc.get(), true);		
+		initialise(beautiDoc.getMCMC(), true);
 	}
 	
 		  
@@ -563,7 +554,9 @@ public class XML2HTMLPaneFX extends Application {
 
 		MethodsText.clear();
 		try {
-			initialise((MCMC) beautiDoc.mcmc.get(), false);
+			// beautiDoc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+			// ClassCastException on a plain (MCMC) beautiDoc.mcmc.get() cast.
+			initialise(beautiDoc.getMCMC(), false);
 			load(html);
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -642,7 +635,9 @@ public class XML2HTMLPaneFX extends Application {
 	
 	public void initialise(MCMC mcmc, boolean update) throws Exception {		
 		xml2textProducer = new XML2Text(beautiDoc);
-		xml2textProducer.initialise((MCMC) beautiDoc.mcmc.get());
+		// beautiDoc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+		// ClassCastException on a plain (MCMC) beautiDoc.mcmc.get() cast.
+		xml2textProducer.initialise(beautiDoc.getMCMC());
 		m = xml2textProducer.getPhrases();
 		
 		html = header + Phrase.toHTML(beautiDoc, m) + footer + "</body>\n</html>";
@@ -740,7 +735,9 @@ public class XML2HTMLPaneFX extends Application {
 	public String getText(CitationPhrase.mode mode) throws Exception {		
 		CitationPhrase.CitationMode = mode;
 		xml2textProducer = new XML2Text(beautiDoc);
-		xml2textProducer.initialise((MCMC) beautiDoc.mcmc.get());
+		// beautiDoc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+		// ClassCastException on a plain (MCMC) beautiDoc.mcmc.get() cast.
+		xml2textProducer.initialise(beautiDoc.getMCMC());
 		m = xml2textProducer.getPhrases();
 		return Phrase.toString(m);
 	}

--- a/beast-fx/src/main/java/beastfx/app/methodsection/XML2Text.java
+++ b/beast-fx/src/main/java/beastfx/app/methodsection/XML2Text.java
@@ -1,17 +1,6 @@
 package beastfx.app.methodsection;
 
 
-
-
-
-
-
-import java.io.File;
-import java.io.PrintStream;
-import java.util.*;
-
-import beastfx.app.util.OutFile;
-import beastfx.app.util.XMLFile;
 import beast.base.core.BEASTInterface;
 import beast.base.core.Description;
 import beast.base.core.Input;
@@ -26,7 +15,6 @@ import beast.base.inference.CompoundDistribution;
 import beast.base.inference.Distribution;
 import beast.base.inference.MCMC;
 import beast.base.inference.Operator;
-import beast.base.inference.StateNode;
 import beast.base.parser.ClassToPackageMap;
 import beast.base.parser.XMLParser;
 import beast.base.spec.evolution.likelihood.GenericTreeLikelihood;
@@ -37,6 +25,12 @@ import beastfx.app.inputeditor.BeautiDoc;
 import beastfx.app.methodsection.Phrase.PhraseType;
 import beastfx.app.methodsection.implementation.BEASTObjectMethodsText;
 import beastfx.app.tools.Application;
+import beastfx.app.util.OutFile;
+import beastfx.app.util.XMLFile;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.util.*;
 
 
 @Description("Convert MCMC analysis in XML file to a methods section")
@@ -92,16 +86,21 @@ public class XML2Text extends beast.base.inference.Runnable {
 		}
 		
 		XMLParser parser = new XMLParser();
-		MCMC mcmc = (MCMC) parser.parseFile(file);
-		beautiDoc.mcmc.setValue(mcmc, beautiDoc);
+		// keep whatever the file's top-level Runnable actually is (MCMC, or a driver like
+		// PathSampler that wraps one) rather than pre-unwrapping it away; beautiDoc.getMCMC()
+		// below unwraps it on demand instead of hard-casting straight to MCMC.
+		beast.base.inference.Runnable runnable = parser.parseFile(file);
+		beautiDoc.mcmc.setValue(runnable, beautiDoc);
 		for (BEASTInterface o : InputFilter.getDocumentObjects(beautiDoc.mcmc.get())) {
 			beautiDoc.registerPlugin(o);
 		}
 		beautiDoc.determinePartitions();
 		BEASTObjectMethodsText.setBeautiCFG(beautiDoc.beautiConfig);
-		
+
 		MethodsText.initNameMap();
-		initialise((MCMC) beautiDoc.mcmc.get());
+		// beautiDoc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+		// ClassCastException on a plain (MCMC) beautiDoc.mcmc.get() cast.
+		initialise(beautiDoc.getMCMC());
 		
 		
 		if (outputInput.get() != null) {

--- a/beast-fx/src/test/java/test/beastfx/app/beauti/BeautiBase.java
+++ b/beast-fx/src/test/java/test/beastfx/app/beauti/BeautiBase.java
@@ -16,11 +16,11 @@ import beastfx.app.inputeditor.AlignmentListInputEditor.Partition0;
 import beastfx.app.inputeditor.BeautiConfig;
 import beastfx.app.inputeditor.BeautiDoc;
 import javafx.application.Platform;
-import javafx.geometry.Bounds;
-import javafx.geometry.Rectangle2D;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.ObservableList;
 import javafx.embed.swing.SwingFXUtils;
+import javafx.geometry.Bounds;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.SnapshotParameters;
@@ -53,7 +53,6 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 
 
 /**
@@ -209,7 +208,9 @@ public class BeautiBase extends ApplicationExtension {
 	}
 
 	String operatorsAsString() {
-		MCMC mcmc = (MCMC) doc.mcmc.get();
+		// doc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+		// ClassCastException on a plain (MCMC) doc.mcmc.get() cast.
+		MCMC mcmc = doc.getMCMC();
 		List<Operator> operators = mcmc.operatorsInput.get();
 		return "assertOperatorsEqual" + pluginListAsString(operators);
 	}
@@ -326,7 +327,9 @@ public class BeautiBase extends ApplicationExtension {
 	void assertOperatorsEqual(String... ids) {
 		if (skipAssertions) return;
 		System.err.println("assertOperatorsEqual");
-		MCMC mcmc = (MCMC) doc.mcmc.get();
+		// doc.getMCMC() unwraps a wrapper Runnable like PathSampler instead of throwing
+		// ClassCastException on a plain (MCMC) doc.mcmc.get() cast.
+		MCMC mcmc = doc.getMCMC();
 		List<Operator> operators = mcmc.operatorsInput.get();
 		asserListsEqual(operators, ids);
 	}

--- a/beast-fx/src/test/java/test/beastfx/app/inputeditor/BeautiDocWrapperRunnableTest.java
+++ b/beast-fx/src/test/java/test/beastfx/app/inputeditor/BeautiDocWrapperRunnableTest.java
@@ -1,0 +1,416 @@
+package test.beastfx.app.inputeditor;
+
+
+import beast.base.core.BEASTInterface;
+import beast.base.core.Input;
+import beast.base.evolution.alignment.Taxon;
+import beast.base.evolution.alignment.TaxonSet;
+import beast.base.evolution.operator.TipDatesRandomWalker;
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import beast.base.inference.CompoundDistribution;
+import beast.base.inference.MCMC;
+import beast.base.inference.Operator;
+import beast.base.inference.State;
+import beast.base.parser.PartitionContext;
+import beast.base.spec.domain.Real;
+import beast.base.spec.evolution.tree.MRCAPrior;
+import beast.base.spec.inference.operator.ScaleOperator;
+import beast.base.spec.inference.parameter.RealScalarParam;
+import beastfx.app.beauti.OperatorListInputEditor;
+import beastfx.app.inputeditor.*;
+import beastfx.app.inputeditor.InputEditor.ExpandOption;
+import javafx.application.Platform;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * Regression tests for issue #131 and PRs #132 / #133.
+ *
+ * BEAUti assumes the active analysis (BeautiDoc.mcmc) is always an MCMC, and used to hard-cast
+ * it as such in many places. That assumption breaks for a wrapper Runnable such as
+ * modelselection.inference.PathSampler, which does not extend MCMC but instead holds its own
+ * MCMC via an input named "mcmc" (e.g. for path-sampling/stepping-stone model selection). Since
+ * that package is not a dependency of this repo, {@link WrapperRunnable} below stands in for it:
+ * same shape ({@link BeautiDoc#getMCMC()} and friends look for an input literally named "mcmc"
+ * on a non-MCMC Runnable), without needing the real package on the test classpath.
+ *
+ * Each test below simulates one BEAUti interaction (applying a template connector, evaluating a
+ * connector's guard condition, populating a panel, opening the Operators panel, toggling tip-date
+ * sampling) while {@link WrapperRunnable} is the active runnable, and checks that BEAUti reaches
+ * through to the wrapper's inner MCMC instead of throwing or silently doing nothing.
+ */
+@ExtendWith(ApplicationExtension.class)
+public class BeautiDocWrapperRunnableTest {
+
+	/** Minimal stand-in for modelselection.inference.PathSampler: a Runnable that is not
+	 *  itself an MCMC, but wraps one via an input named "mcmc". */
+	public static class WrapperRunnable extends beast.base.inference.Runnable {
+		final public Input<MCMC> mcmcInput = new Input<>("mcmc", "wrapped MCMC", Input.Validate.REQUIRED);
+		@Override public void initAndValidate() {}
+		@Override public void run() throws Exception {}
+	}
+
+
+	@Start
+	public void start(Stage stage) {
+		// nothing to show, only the JavaFX toolkit is required
+	}
+
+
+	/** a minimal but otherwise ordinary MCMC: empty operator list, one loggable parameter. */
+	private static MCMC newMCMC(String id) {
+		CompoundDistribution posterior = new CompoundDistribution();
+		posterior.setID("posterior." + id);
+		posterior.initAndValidate();
+
+		RealScalarParam<Real> param = new RealScalarParam<>(1.0, Real.INSTANCE);
+		param.setID("param." + id);
+		State state = new State();
+		state.initByName("stateNode", param);
+		state.setID("state." + id);
+
+		beast.base.inference.Logger logger = new beast.base.inference.Logger();
+		logger.setID("logger." + id);
+		logger.initByName("log", param);
+
+		beast.base.inference.OperatorSchedule schedule = new beast.base.inference.OperatorSchedule();
+		schedule.setID("operatorschedule." + id);
+
+		MCMC mcmc = new MCMC();
+		mcmc.setID(id);
+		mcmc.initByName("chainLength", 1000L, "state", state, "distribution", posterior,
+				"operator", new ArrayList<Operator>(), "logger", logger, "operatorschedule", schedule);
+		return mcmc;
+	}
+
+	private static WrapperRunnable newWrapper(String id, MCMC inner) {
+		WrapperRunnable wrapper = new WrapperRunnable();
+		wrapper.setID(id);
+		wrapper.initByName("mcmc", inner);
+		return wrapper;
+	}
+
+	/**
+	 * Puts a wrapper Runnable in charge of doc, the way BEAUti would after the user selects a
+	 * PathSampler-style template: doc.mcmc points at the wrapper, and both the wrapper and its
+	 * inner MCMC are registered under doc so BeautiDoc can look them up by ID.
+	 *
+	 * @return the wrapper's inner MCMC, for the test to act on directly
+	 */
+	private static MCMC activateWrapperRunnable(BeautiDoc doc) {
+		MCMC inner = newMCMC("inner");
+		WrapperRunnable wrapper = newWrapper("pathSampler", inner);
+		doc.mcmc.setValue(wrapper, doc);
+		doc.registerPlugin(wrapper);
+		doc.registerPlugin(inner);
+		return inner;
+	}
+
+	/** a standalone Operator, suitable for connecting/disconnecting/toggling in a test --
+	 *  its own construction is not what's under test. */
+	private static ScaleOperator newTestOperator(String id) {
+		RealScalarParam<Real> scaleParam = new RealScalarParam<>(2.0, Real.INSTANCE);
+		scaleParam.setID("scaleParam." + id);
+		ScaleOperator operator = new ScaleOperator();
+		operator.setID(id);
+		operator.initByName("parameter", scaleParam, "weight", 1.0, "scaleFactor", 0.7);
+		return operator;
+	}
+
+
+	/**
+	 * Scenario: BeautiDoc.getMCMC() is called with a wrapper Runnable, and separately with a
+	 * plain MCMC. It should unwrap the wrapper to its inner MCMC, and return a plain MCMC as-is.
+	 */
+	@Test
+	public void getMCMCUnwrapsWrapperRunnable() {
+		MCMC inner = newMCMC("inner");
+		WrapperRunnable wrapper = newWrapper("pathSampler", inner);
+
+		assertSame(inner, BeautiDoc.getMCMC(wrapper),
+				"getMCMC() should unwrap a wrapper Runnable to its inner MCMC");
+		assertSame(inner, BeautiDoc.getMCMC(inner),
+				"getMCMC() should return a plain MCMC as-is");
+	}
+
+
+	/**
+	 * Scenario: a template rule such as {@code <connect targetID='mcmc' inputName='operator' .../>}
+	 * is applied and then reversed against a wrapper Runnable -- this is what
+	 * BeautiDoc.scrubAll() does every time a partition or model choice changes in BEAUti,
+	 * calling connect() when the rule's condition holds and disconnect() when it doesn't.
+	 * Both should act on the wrapper's inner MCMC, not the wrapper itself.
+	 *
+	 * Bug fixed by PR #133: only connect() redirected to the inner MCMC; disconnect() resolved
+	 * the wrapper itself, found no "operator" input on it, and the resulting
+	 * IllegalArgumentException was swallowed by scrubAll()'s catch-and-print. So an object
+	 * connected via a wrapper could be added but never removed again.
+	 */
+	@Test
+	public void connectThenDisconnectViaWrapperNetsToRemoved() throws Exception {
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		runOnFXThread(() -> {
+			// given a wrapper Runnable is active, and an operator to wire in
+			BeautiDoc doc = new BeautiDoc();
+			MCMC inner = activateWrapperRunnable(doc);
+			Operator operator = newTestOperator("op1");
+			doc.registerPlugin(operator);
+			PartitionContext ctx = new PartitionContext("", "", "", "");
+			BeautiConnector connector = new BeautiConnector("op1", "mcmc", "operator", null);
+
+			// when the rule's condition holds, connect() should reach the inner MCMC
+			doc.connect(connector, ctx);
+			assertTrue(inner.operatorsInput.get().contains(operator),
+					"connect() should add the operator to the wrapper's inner MCMC");
+
+			// when the condition no longer holds, disconnect() should reach it too
+			doc.disconnect(connector, ctx);
+			assertFalse(inner.operatorsInput.get().contains(operator),
+					"disconnect() should remove the operator from the inner MCMC again (issue #131/#133 regression)");
+		}, error);
+		if (error.get() != null) {
+			throw new AssertionError(error.get());
+		}
+	}
+
+
+	/**
+	 * Scenario: a connector's {@code nooperator(op1)} guard condition -- used by templates to
+	 * skip a rule once a given operator already exists -- is evaluated while a wrapper Runnable
+	 * is active. It should read op1's presence from the wrapper's inner MCMC operator list, not
+	 * the wrapper (which has no operator list of its own).
+	 *
+	 * Bug fixed by PR #132: isActivated() read {@code ((MCMC) doc.mcmc.get()).operatorsInput}
+	 * directly, throwing ClassCastException for a wrapper Runnable before it could even check
+	 * whether op1 was present.
+	 */
+	@Test
+	public void connectorIsActivatedNoOperatorConditionUsesInnerMCMC() throws Exception {
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		runOnFXThread(() -> {
+			// given a wrapper Runnable is active, and an operator that is not yet connected
+			BeautiDoc doc = new BeautiDoc();
+			MCMC inner = activateWrapperRunnable(doc);
+			Operator operator = newTestOperator("op1");
+			doc.registerPlugin(operator);
+			PartitionContext ctx = new PartitionContext("", "", "", "");
+			List<BEASTInterface> empty = new ArrayList<>();
+			BeautiConnector connector = new BeautiConnector("someSrc", "someTarget", "someInput", "nooperator(op1)");
+
+			// while op1 is absent from the inner MCMC, "no operator" should hold
+			assertTrue(connector.isActivated(ctx, empty, empty, doc),
+					"nooperator(op1) should hold before op1 is in the wrapper's inner MCMC operator list");
+
+			// once op1 is added to the inner MCMC, "no operator" should no longer hold
+			inner.operatorsInput.get().add(operator);
+			assertFalse(connector.isActivated(ctx, empty, empty, doc),
+					"nooperator(op1) should no longer hold once op1 is in the inner MCMC's operator list (issue #131/#132 regression)");
+		}, error);
+		if (error.get() != null) {
+			throw new AssertionError(error.get());
+		}
+	}
+
+
+	/**
+	 * Scenario: the Operators panel's configuration ({@code path="operator"}) is resolved while
+	 * a wrapper Runnable is active -- this is what actually populates the Partitions, Priors,
+	 * and Operators panels in BEAUti. It should walk down into the wrapper's inner MCMC operator
+	 * list, rather than fail because the wrapper has no "operator" input of its own.
+	 *
+	 * Bug fixed by PR #132: resolveInput() called beastObject.getInput("operator") on the
+	 * wrapper directly, which threw IllegalArgumentException -- caught by resolveInput()'s own
+	 * catch-all and logged, leaving the panel silently empty instead of showing the operators.
+	 */
+	@Test
+	public void panelConfigResolveInputFallsBackToInnerMCMC() throws Exception {
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		runOnFXThread(() -> {
+			// given a wrapper Runnable is active, with one operator already on its inner MCMC
+			BeautiDoc doc = new BeautiDoc();
+			MCMC inner = activateWrapperRunnable(doc);
+			Operator operator = newTestOperator("op1");
+			inner.operatorsInput.get().add(operator);
+
+			// and a panel configured the same way the real Operators panel is: path="operator"
+			BeautiPanelConfig panelConfig = new BeautiPanelConfig();
+			panelConfig.initByName("panelname", "Operators", "tiptext", "operators", "path", "operator");
+
+			// resolving the panel's input should find the inner MCMC's operators, not fail silently
+			Input<?> resolved = panelConfig.resolveInput(doc, 0);
+			assertNotNull(resolved,
+					"resolveInput() should not silently fail for a wrapper Runnable (issue #131/#132 regression)");
+			assertTrue(((List<?>) resolved.get()).contains(operator),
+					"the Operators panel should resolve to the wrapper's inner MCMC operator list");
+		}, error);
+		if (error.get() != null) {
+			throw new AssertionError(error.get());
+		}
+	}
+
+
+	/**
+	 * Scenario: the Operators panel is opened while a wrapper Runnable is active. Beneath the
+	 * operator list, it also builds a sub-editor for the operator schedule; that sub-editor
+	 * should be built against the wrapper's inner MCMC, not throw trying to read
+	 * "operatorschedule" off the wrapper itself.
+	 *
+	 * Bug fixed by PR #133: OperatorListInputEditor read doc.mcmc.get() unchecked/uncast for the
+	 * "operatorschedule" input, so it was missed by #131's (MCMC)-cast sweep, but failed the
+	 * same way for a wrapper Runnable -- getInput("operatorschedule") throws
+	 * IllegalArgumentException for an unknown input name.
+	 */
+	@Test
+	public void operatorListInputEditorUsesInnerMCMCOperatorSchedule() throws Exception {
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		runOnFXThread(() -> {
+			BeautiDoc doc = new BeautiDoc();
+			// BEASTObjectInputEditor.init() (used for the operatorschedule sub-editor)
+			// needs a loaded BeautiConfig regardless of addButtons
+			doc.loadTemplate(doc.processTemplate(BeautiConfig.TEMPLATE_DIR + "/Standard.xml"));
+			MCMC inner = activateWrapperRunnable(doc);
+
+			// opening the Operators panel builds this editor against doc.mcmc.get() (the wrapper)
+			OperatorListInputEditor editor = new OperatorListInputEditor(doc);
+			editor.init(inner.operatorsInput, inner, -1, ExpandOption.FALSE, false);
+		}, error);
+		if (error.get() != null) {
+			error.get().printStackTrace();
+			fail("OperatorListInputEditor.init() should not throw for a wrapper Runnable: " + error.get());
+		}
+	}
+
+
+	/**
+	 * Scenario: an MRCA prior's "sample tip dates" checkbox (Priors panel) is switched on and
+	 * then off while a wrapper Runnable is active. Turning it on should add a
+	 * TipDatesRandomWalker operator to the wrapper's inner MCMC; turning it off should remove it
+	 * again.
+	 *
+	 * Bug fixed by PR #133: MRCAPriorInputEditor read/wrote doc.mcmc.get()'s "operator" input
+	 * unchecked/uncast, so like OperatorListInputEditor it was missed by #131's cast sweep but
+	 * failed the same way for a wrapper Runnable.
+	 */
+	@Test
+	public void tipDateSamplingToggleUsesInnerMCMCOperatorList() throws Exception {
+		AtomicReference<Throwable> error = new AtomicReference<>();
+		runOnFXThread(() -> {
+			// given a wrapper Runnable is active
+			BeautiDoc doc = new BeautiDoc();
+			MCMC inner = activateWrapperRunnable(doc);
+
+			// and an MRCA prior on a two-taxon tree, as the Priors panel would show
+			Tree tree = new TreeParser("(A:1.0,B:1.0):0.0;", false);
+			tree.setID("tree.t:test");
+			Taxon a = new Taxon();
+			a.setID("A");
+			Taxon b = new Taxon();
+			b.setID("B");
+			TaxonSet taxonset = new TaxonSet();
+			taxonset.initByName("taxon", a, "taxon", b);
+			taxonset.setID("ab.taxonset");
+			MRCAPrior prior = new MRCAPrior();
+			prior.initByName("tree", tree, "taxonset", taxonset);
+			prior.setID("ab.prior");
+			doc.registerPlugin(tree);
+			doc.registerPlugin(taxonset);
+			doc.registerPlugin(prior);
+
+			// the editor's m_beastObject is normally set by init(), which needs a full UI
+			// build we don't want here -- reach around it directly instead
+			MRCAPriorInputEditor editor = new MRCAPriorInputEditor(doc);
+			setBeastObject(editor, prior);
+
+			// when "sample tip dates" is switched on, the operator should land on the inner MCMC
+			invokePrivate(MRCAPriorInputEditor.class, "enableTipSampling", editor);
+			assertTrue(hasTipDatesRandomWalker(inner),
+					"enableTipSampling() should add a TipDatesRandomWalker to the wrapper's inner MCMC");
+
+			// when switched off again, it should come off the inner MCMC too
+			invokeStaticPrivate(MRCAPriorInputEditor.class, "disableTipSampling",
+					new Class<?>[] { BEASTInterface.class, BeautiDoc.class }, prior, doc);
+			assertFalse(hasTipDatesRandomWalker(inner),
+					"disableTipSampling() should remove the TipDatesRandomWalker from the inner MCMC again");
+		}, error);
+		if (error.get() != null) {
+			error.get().printStackTrace();
+			fail("tip-date sampling toggle should not throw for a wrapper Runnable: " + error.get());
+		}
+	}
+
+
+	private static boolean hasTipDatesRandomWalker(MCMC mcmc) {
+		for (Operator op : mcmc.operatorsInput.get()) {
+			if (op instanceof TipDatesRandomWalker) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+
+	/** m_beastObject has no public setter outside of the full init(...) UI build, which
+	 *  needs a loaded BeautiConfig template; reach around it directly instead. */
+	private static void setBeastObject(InputEditor.Base editor, BEASTInterface beastObject) throws Exception {
+		Field field = InputEditor.Base.class.getDeclaredField("m_beastObject");
+		field.setAccessible(true);
+		field.set(editor, beastObject);
+	}
+
+	private static void invokePrivate(Class<?> clazz, String name, Object target) throws Exception {
+		Method method = clazz.getDeclaredMethod(name);
+		method.setAccessible(true);
+		try {
+			method.invoke(target);
+		} catch (java.lang.reflect.InvocationTargetException e) {
+			throw (e.getCause() instanceof Exception) ? (Exception) e.getCause() : e;
+		}
+	}
+
+	private static void invokeStaticPrivate(Class<?> clazz, String name, Class<?>[] paramTypes, Object... args) throws Exception {
+		Method method = clazz.getDeclaredMethod(name, paramTypes);
+		method.setAccessible(true);
+		try {
+			method.invoke(null, args);
+		} catch (java.lang.reflect.InvocationTargetException e) {
+			throw (e.getCause() instanceof Exception) ? (Exception) e.getCause() : e;
+		}
+	}
+
+
+	/** run task on the JavaFX application thread, recording any exception in error **/
+	private static void runOnFXThread(FXTask task, AtomicReference<Throwable> error) throws InterruptedException {
+		CountDownLatch latch = new CountDownLatch(1);
+		Platform.runLater(() -> {
+			try {
+				task.run();
+			} catch (Throwable e) {
+				error.set(e);
+			} finally {
+				latch.countDown();
+			}
+		});
+		if (!latch.await(120, TimeUnit.SECONDS)) {
+			throw new AssertionError("timed out waiting for JavaFX thread");
+		}
+	}
+
+	private interface FXTask {
+		void run() throws Exception;
+	}
+}


### PR DESCRIPTION
see #131

## Summary

BEAUti's `BeautiDoc.mcmc` input is typed as `beast.base.inference.Runnable`, but most of
beast-fx assumed it was always safe to hard-cast it to `MCMC`. That assumption breaks for
wrapper Runnables — e.g. `modelselection.inference.PathSampler` (from the model-selection
package, see BEAST2-Dev/model-selection#15) — which hold their own `MCMC` via a named input
`"mcmc"` instead of extending `MCMC` directly. Selecting such a template in BEAUti threw
`ClassCastException` from a dozen+ call sites (Partitions, Clock Model, Site Model, State
Node Initialiser, Operators/connectors, Methods-section text generation).

## Changes

- Add `BeautiDoc.getMCMC()` / `BeautiDoc.getMCMC(Runnable)`: return the value as-is if it's
  already an `MCMC`, otherwise unwrap its inner `"mcmc"` input if present, otherwise `null`.
- Replace `(MCMC) doc.mcmc.get()` / `(MCMC) mcmc.get()` hard casts with `doc.getMCMC()`
  throughout `BeautiDoc`, `BeautiConnector`, `BeautiPanel`, `BeautiTabPane`,
  `AlignmentListInputEditor`, `ClockModelListInputEditor`,
  `StateNodeInitialiserListInputEditor`, `SiteModelInputEditor` (both packages), `XML2Text`,
  `XML2HTMLPane`, `XML2HTMLPaneFX`, and the `BeautiBase` test helper; add null-checks where a
  wrapper may have no MCMC yet.
- `BeautiDoc.connectByInput()`: if a `<connect targetID='mcmc' .../>` target lacks the
  requested input but has an inner `"mcmc"` input that does, retry against that inner object.
- `BeautiPanelConfig`: same fallback when resolving a panel's configured input path, so panels
  built against a plain `MCMC` (Partitions, Priors, Operators, ...) still populate correctly.
- `XML2Text` / `XML2HTMLPane` / `XML2HTMLPaneFX`: stop pre-casting a freshly parsed file's
  top-level object to `MCMC` before storing it — keep the real `Runnable` and let `getMCMC()`
  unwrap it on demand.