### PR TITLE
Make disconnect() symmetric with connect(), and cover two remaining wrapper sites

### DIFF
--- a/beast-fx/src/main/java/beastfx/app/beauti/OperatorListInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/beauti/OperatorListInputEditor.java
@@ -20,6 +20,7 @@ import beastfx.app.inputeditor.ListInputEditor;
 import beastfx.app.util.FXUtils;
 import beast.base.core.BEASTInterface;
 import beast.base.core.Input;
+import beast.base.inference.MCMC;
 import beast.base.inference.Operator;
 import beast.base.inference.StateNode;
 
@@ -62,9 +63,15 @@ public class OperatorListInputEditor extends ListInputEditor {
     	m_buttonStatus = ButtonStatus.NONE;
     	super.init(input, beastObject, itemNr, isExpandOption, addButtons);
     	
-    	BEASTObjectInputEditor osEditor = new BEASTObjectInputEditor(doc);
-    	osEditor.init(((BEASTInterface) doc.mcmc.get()).getInput("operatorschedule"), (BEASTInterface) doc.mcmc.get(), -1, isExpandOption, addButtons);
-    	((BorderPane)pane).setBottom(osEditor);
+    	// the operator schedule lives on the MCMC, which for a wrapper Runnable like PathSampler
+    	// is the inner one -- doc.mcmc.get() itself has no "operatorschedule" input, and
+    	// getInput() would throw IllegalArgumentException rather than return null
+    	MCMC mcmc = doc.getMCMC();
+    	if (mcmc != null) {
+    		BEASTObjectInputEditor osEditor = new BEASTObjectInputEditor(doc);
+    		osEditor.init(mcmc.getInput("operatorschedule"), mcmc, -1, isExpandOption, addButtons);
+    		((BorderPane)pane).setBottom(osEditor);
+    	}
     }
     
     @Override

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
@@ -1857,6 +1857,27 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
     }
 
 
+    /**
+     * A wrapper Runnable such as a path-sampling/stepping-stone driver (see
+     * modelselection.inference.PathSampler) does not itself have MCMC's usual inputs
+     * (logger, operator, state, ...) -- it holds its own MCMC via an input named "mcmc"
+     * instead of extending MCMC directly. If the target lacks the requested input but has
+     * one named "mcmc", redirect to that inner MCMC so <connect targetID='mcmc' .../> rules
+     * written for a plain MCMC still work when such a wrapper is the active runnable.
+     * Must be used by both connect() and disconnect(), otherwise objects can be connected
+     * to the inner MCMC but never removed from it again.
+     */
+    private BEASTInterface redirectToInnerMCMC(BEASTInterface target, String inputName) {
+        if (target != null && !target.getInputs().containsKey(inputName) && target.getInputs().containsKey("mcmc")) {
+            Object inner = target.getInputValue("mcmc");
+            if (inner instanceof BEASTInterface && ((BEASTInterface) inner).getInputs().containsKey(inputName)) {
+                return (BEASTInterface) inner;
+            }
+        }
+        return target;
+    }
+
+
     public void connect(BEASTInterface srcBEASTObject, String targetID, String inputName) {
         try {
             BEASTInterface target = pluginmap.get(targetID);
@@ -1864,18 +1885,7 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
                 Log.trace.println("BeautiDoc: Could not find object " + targetID);
                 return;
             }
-            // A wrapper Runnable such as a path-sampling/stepping-stone driver (see
-            // modelselection.inference.PathSampler) does not itself have MCMC's usual inputs
-            // (logger, operator, state, ...) -- it holds its own MCMC via an input named "mcmc"
-            // instead of extending MCMC directly. If the target lacks the requested input but has
-            // one named "mcmc", retry against that inner MCMC so <connect targetID='mcmc' .../>
-            // rules written for a plain MCMC still work when such a wrapper is the active runnable.
-            if (!target.getInputs().containsKey(inputName) && target.getInputs().containsKey("mcmc")) {
-                Object inner = target.getInputValue("mcmc");
-                if (inner instanceof BEASTInterface && ((BEASTInterface) inner).getInputs().containsKey(inputName)) {
-                    target = (BEASTInterface) inner;
-                }
-            }
+            target = redirectToInnerMCMC(target, inputName);
             // prevent duplication inserts in list
             Object o = target.getInputValue(inputName);
             if (o instanceof List) {
@@ -1901,6 +1911,11 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
         }
         BEASTInterface srcBEASTObject = pluginmap.get(translatePartitionNames(connector.sourceID, context));
         String targetID = translatePartitionNames(connector.targetID, context);
+        // same targetID translation as connect(BeautiConnector, PartitionContext) does, so that
+        // <connect targetID='mcmc' .../> resolves for a runnable whose ID is not literally "mcmc"
+    	if (targetID.equals("mcmc")) {
+    		targetID = mcmc.get().getID();
+    	}
         disconnect(srcBEASTObject, targetID, connector.targetInput);
     }
 
@@ -1910,6 +1925,7 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
             if (target == null) {
                 return;
             }
+            target = redirectToInnerMCMC(target, inputName);
             final Input<?> input = target.getInput(inputName);
             Object o = input.get();
             if (o instanceof List) {

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/MRCAPriorInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/MRCAPriorInputEditor.java
@@ -32,6 +32,7 @@ import beast.base.spec.inference.parameter.RealScalarParam;
 import beast.base.evolution.tree.Tree;
 import beast.base.inference.CompoundDistribution;
 import beast.base.inference.Distribution;
+import beast.base.inference.MCMC;
 import beast.base.inference.Operator;
 import beast.base.inference.State;
 import beast.base.parser.PartitionContext;
@@ -325,8 +326,14 @@ public class MRCAPriorInputEditor extends InputEditor.Base implements HasExpandB
     		operator.initByName("tree", prior.treeInput.get(), "taxonset", taxonset, "windowSize", 1.0, "weight", 1.0);
     	}
    		operator.setID("tipDatesSampler." + taxonset.getID());
-   	    	
-    	doc.mcmc.get().setInputValue("operator", operator);
+
+   		// the operator list lives on the MCMC, which for a wrapper Runnable like PathSampler is
+   		// the inner one -- doc.mcmc.get() itself has no "operator" input, and setInputValue()
+   		// would throw IllegalArgumentException
+   		MCMC mcmc = doc.getMCMC();
+   		if (mcmc != null) {
+   			mcmc.setInputValue("operator", operator);
+   		}
 	}
 
     // remove TipDatesRandomWalker from list of operators
@@ -350,8 +357,12 @@ public class MRCAPriorInputEditor extends InputEditor.Base implements HasExpandB
     		return;
     	}
     	
-    	// remove from list of operators
-    	Object o = doc.mcmc.get().getInput("operator");
+    	// remove from list of operators -- see enableTipSampling() on why this goes via getMCMC()
+    	MCMC mcmc = doc.getMCMC();
+    	if (mcmc == null) {
+    		return;
+    	}
+    	Object o = mcmc.getInput("operator");
     	if (o instanceof Input<?>) {
     		Input<List<Operator>> operatorInput = (Input<List<Operator>>) o;
     		List<Operator> operators = operatorInput.get();


### PR DESCRIPTION
Follow-up to #132 (review findings), targeting `mcmc` so it lands inside that PR rather than separately. See #131.

### 1. `disconnect()` never got the inner-`"mcmc"` redirect

`connect()` gained the redirect in f6a369c; `disconnect()` did not. `scrubAll()` calls the two as the branches of a single decision:

```java
} else if (connector.isActivated(...)) {
    connect(connector, context);
} else {
    disconnect(connector, context);
}
```

So with a wrapper Runnable, objects get connected to the inner MCMC but are never removed from it again: `disconnect()` resolves the wrapper, `target.getInput(inputName)` throws `IllegalArgumentException`, and the surrounding catch-and-print swallows it. The failure is silent — toggling a checkbox off, deleting a partition, or switching a clock model leaves stale operators/loggers on the inner MCMC and the generated XML is wrong rather than crashy.

Extracted the redirect as `redirectToInnerMCMC()` and used it from both, with a javadoc note that it must stay used by both.

Also gave `disconnect(BeautiConnector, PartitionContext)` the `targetID='mcmc' -> mcmc.get().getID()` translation `connect(BeautiConnector, ...)` already has. This is a **no-op for the shipped templates** — `Standard.xml` declares `<run spec="beast.base.inference.MCMC" id="mcmc">`, so the translation resolves to the same string — but it matters for a wrapper template whose runnable carries a different ID.

### 2. Two remaining sites that assume MCMC's inputs

These read MCMC inputs off `doc.mcmc.get()` without a cast, so the `(MCMC)` sweep didn't catch them, but they fail the same way — `getInput()`/`setInputValue()` throw `IllegalArgumentException` for an unknown input name (`BEASTInterface.java:413`):

- `OperatorListInputEditor:66` — `getInput("operatorschedule")`. The Operators panel is in #131's repro list, so this one was still broken.
- `MRCAPriorInputEditor:329/354` — `setInputValue("operator", ...)` and `getInput("operator")`, i.e. the tip-date sampling toggle.

Both routed through `doc.getMCMC()`, following the null-guard style already used elsewhere in #132.

### Verification

- `mvn -o -pl beast-fx -am -DskipTests compile` clean.
- Headless BEAUti tests: `BeautiMRCAPriorTest` 1/1 pass, `LinkUnlinkTest` 14 run / 0 failures / 7 skipped (pre-existing `@Disabled`). BUILD SUCCESS.

### Not addressed here

Null handling across #132 is still split roughly half-and-half — `BeautiDoc:1595`/`:1641` (`getMCMC().posteriorInput.get()` in `scrubAll`/`setUpActivePlugins`) and the `deepCopyPlugin` call sites will NPE where other sites carefully guard. That's a contract decision for you: either those are bugs, or the guards are dead code and `getMCMC()` should throw a named `IllegalStateException` instead of returning null. Left alone deliberately so this PR stays reviewable.