### PR TITLE
Reject interval scaling that breaches a sampled-ancestor ceiling

### DIFF
--- a/beast-base/src/main/java/beast/base/evolution/tree/Node.java
+++ b/beast-base/src/main/java/beast/base/evolution/tree/Node.java
@@ -845,16 +845,26 @@ public class Node extends BEASTObject {
     /**
      * Interval scaling: multiply this node's "margin" (height above its taller
      * child) by {@code scale}, recursively. Tip heights are preserved by
-     * construction, so the resulting tree is always valid for any positive
-     * scale factor.
+     * construction, so on a tree without sampled ancestors the result is valid
+     * for any positive scale factor.
      * <p>
      * Used by {@link Tree#scale(double)} as the contract-bound dilation
      * operation. Each margin is independently multiplied by {@code scale}, so
      * the tree's sum of margins (= {@link Tree#getScalableValue()}) is
      * exactly multiplied by {@code scale}.
+     * <p>
+     * A fake (sampled-ancestor) node keeps its own height &mdash; it is pinned
+     * to its direct-ancestor leaf's sampling time &mdash; while the subtree
+     * below it scales, so it caps how far that subtree can rise. Reaching the
+     * cap throws {@link IllegalArgumentException}, which callers treat as a
+     * rejection (see {@link Tree#scale(double)}). The check costs nothing on a
+     * tree with no fake nodes, so it stays on this single traversal rather than
+     * in a separate validation pass.
      *
      * @param scale positive scale factor
      * @return number of intervals (margins) scaled, for HR calculations
+     * @throws IllegalArgumentException if a fake node's child reaches or passes
+     *         the fake node's pinned height
      */
     public int intervalScale(final double scale) {
         if (isLeaf()) {
@@ -862,11 +872,20 @@ public class Node extends BEASTObject {
         }
         // sampled-ancestor fake nodes: skip, recurse into the non-direct-ancestor child
         if (isFake()) {
-            if (getLeft().isDirectAncestor()) {
-                return getRight().intervalScale(scale);
-            } else {
-                return getLeft().intervalScale(scale);
+            final Node child = getLeft().isDirectAncestor() ? getRight() : getLeft();
+            final int dof = child.intervalScale(scale);
+            // Only a child that moved can breach the ceiling. A leaf child sits at a
+            // fixed sampling time, so if it were already at or above this node the
+            // tree was malformed before the move -- rejecting every proposal over it
+            // would stall the chain rather than reject a bad move.
+            if (!child.isLeaf() && child.getHeight() >= height) {
+                throw new IllegalArgumentException(
+                        "Interval scaling by " + scale + " lifted node " + child.getNr()
+                        + " to height " + child.getHeight()
+                        + ", at or above the sampled ancestor at height " + height
+                        + " that must remain its ancestor.");
             }
+            return dof;
         }
         startEditing();
         final double oldMargin = height - Math.max(getLeft().getHeight(), getRight().getHeight());

--- a/beast-base/src/main/java/beast/base/evolution/tree/Tree.java
+++ b/beast-base/src/main/java/beast/base/evolution/tree/Tree.java
@@ -663,10 +663,30 @@ public class Tree extends StateNode implements TreeInterface, Function, Scalable
      * Equivalent to interval scaling: see {@link #getScalableValue()} for the
      * summary that scales by exactly {@code scale} under this operation.
      * <p>
-     * Always succeeds for any positive {@code scale} (no leaf can violate a
-     * branch-length constraint, because each margin remains positive).
+     * On a tree without sampled ancestors this always succeeds for any positive
+     * {@code scale}: leaf heights are fixed and each margin stays positive, so
+     * no branch-length constraint can be violated.
+     * <p>
+     * A sampled-ancestor tree is different. A fake node's height is pinned to
+     * its direct-ancestor leaf's sampling time, so it cannot move, and it acts
+     * as a fixed <em>ceiling</em> on the subtree hanging below it. The vertical
+     * room between that ceiling and the fixed leaves underneath is finite, so a
+     * large enough {@code scale > 1} lifts the fake node's child through it.
+     * Such a move has no valid state to land in and is rejected by throwing
+     * {@link IllegalArgumentException}, per the {@link Scalable} contract.
+     * <p>
+     * The breach is detected as the scale walks the tree, so a rejected move can
+     * leave heights below the offending fake node already scaled. That is the
+     * rejection path every scale operator already takes: the throw becomes a
+     * {@code NEGATIVE_INFINITY} proposal and {@code MCMC} restores the state.
+     * Callers driving {@code scale} outside an MCMC step need to restore state
+     * themselves. Detecting the breach up front would mean a second full
+     * traversal on every proposal, including the trees with no sampled ancestors
+     * where it can never fire &mdash; not worth paying on the common path.
      *
      * @return log Jacobian determinant of the move ({@code dof × log(scale)})
+     * @throws IllegalArgumentException if the move lifts a fake node's child to
+     *         or above the fake node's pinned height
      */
     @Override
     public double scale(final double scale) {

--- a/beast-base/src/main/java/beast/base/spec/evolution/operator/IntervalScaleOperator.java
+++ b/beast-base/src/main/java/beast/base/spec/evolution/operator/IntervalScaleOperator.java
@@ -66,55 +66,33 @@ public class IntervalScaleOperator extends TreeOperator {
 
 	@Override
 	public double proposal() {
-		
-		final Tree tree = (Tree) InputUtil.get(treeInput, this);
+		try {
+			final Tree tree = (Tree) InputUtil.get(treeInput, this);
 
-		double scaler = getScaler();
-		double lengthBefore = getTreeLength(tree);
-		int numbers = resampleNodeHeight(tree.getRoot(), scaler);
-		double lengthAfter = getTreeLength(tree);
-		double actualScaler = lengthAfter / lengthBefore;
-		
-		double logHR = Math.log(scaler) * (numbers);
+			double scaler = getScaler();
+			double lengthBefore = getTreeLength(tree);
+			int numbers = tree.getRoot().intervalScale(scaler);
+			double lengthAfter = getTreeLength(tree);
+			double actualScaler = lengthAfter / lengthBefore;
 
-		// scale returns log Jacobian = dim * log(factor)
-		for (Scalable down : downInput.get()) {
-			logHR += down.scale(1.0/actualScaler);
-		}
-		for (Scalable up : upInput.get()) {
-			logHR += up.scale(actualScaler);
-		}
-		return logHR;
-	}
+			double logHR = Math.log(scaler) * (numbers);
 
-	private int resampleNodeHeight(Node node, double scaler) {
-		if (node.isLeaf()) {
-			return 0;
-		}
-		
-		// deal with sampled ancestors
-		if (node.isFake()) {
-			if (node.getLeft().isDirectAncestor()) {
-				return resampleNodeHeight(node.getRight(), scaler);
-			} else {
-				// node.getRight() must be direct ancestor
-				return resampleNodeHeight(node.getLeft(), scaler);
+			// scale returns log Jacobian = dim * log(factor)
+			for (Scalable down : downInput.get()) {
+				logHR += down.scale(1.0/actualScaler);
 			}
-		}
-		
-		double oldHeights = node.getHeight() - Math.max(node.getLeft().getHeight(), node.getRight().getHeight());
-		int scaledNodeCount = 1;
-		scaledNodeCount += resampleNodeHeight(node.getLeft(), scaler);
-		scaledNodeCount += resampleNodeHeight(node.getRight(), scaler);
+			for (Scalable up : upInput.get()) {
+				logHR += up.scale(actualScaler);
+			}
+			return logHR;
 
-		// resample the height
-		double minHeight = Math.max(node.getLeft().getHeight(), node.getRight().getHeight());
-		double newHeight = oldHeights * scaler;
-		node.setHeight(newHeight + minHeight);
-		
-		return scaledNodeCount;
+		} catch (IllegalArgumentException e) {
+			// a Scalable rejected the move (e.g. a sampled-ancestor ceiling was
+			// hit); per the Scalable contract that is a rejection signal
+			return Double.NEGATIVE_INFINITY;
+		}
 	}
-	
+
 	private double getTreeLength(Tree tree) {
 		double length = 0;
 		for (Node node : tree.getNodesAsArray()) {

--- a/beast-base/src/main/java/beast/base/spec/evolution/operator/UpDownOperator.java
+++ b/beast-base/src/main/java/beast/base/spec/evolution/operator/UpDownOperator.java
@@ -218,37 +218,21 @@ public class UpDownOperator extends KernelOperator {
 	}
 
 
+	/**
+	 * Interval-scale the tree, the same dilation {@link Tree#scale(double)} applies.
+	 * <p>
+	 * Delegates to {@link Node#intervalScale(double)} rather than repeating the
+	 * recursion: a private copy here silently lost the sampled-ancestor ceiling
+	 * check and let this operator lift a node through its pinned sampled ancestor.
+	 *
+	 * @throws IllegalArgumentException if the move breaches a sampled-ancestor
+	 *         ceiling; {@code proposal()} catches this and rejects
+	 */
 	private double scaleTree(TreeInterface tree, double scale) {
-		int dim = resampleNodeHeight(tree.getRoot(), scale);
+		int dim = tree.getRoot().intervalScale(scale);
 		return dim * Math.log(scale);
 	}
 
-	private int resampleNodeHeight(Node node, double scaler) {
-		if (node.isLeaf()) {
-			return 0;
-		}
-		
-		if (node.isFake()) {
-			if (node.getLeft().isDirectAncestor()) {
-				return resampleNodeHeight(node.getRight(), scaler);
-			} else {
-				return resampleNodeHeight(node.getLeft(), scaler);
-			}
-		}
-		
-		double oldHeights = node.getHeight() - Math.max(node.getLeft().getHeight(), node.getRight().getHeight());
-		int scaledNodeCount = 1;
-		scaledNodeCount += resampleNodeHeight(node.getLeft(), scaler);
-		scaledNodeCount += resampleNodeHeight(node.getRight(), scaler);
-
-		// resample the height
-		double minHeight = Math.max(node.getLeft().getHeight(), node.getRight().getHeight());
-		double newHeight = oldHeights * scaler;
-		node.setHeight(newHeight + minHeight);
-		
-		return scaledNodeCount;
-	}
-	
     private boolean outsideBounds(final Scalable node) {
         if (node instanceof RealScalarParam<?> p) {
             if (!p.withinBounds(p.get())) {

--- a/beast-base/src/test/java/beast/base/evolution/tree/TreeScalableTest.java
+++ b/beast-base/src/test/java/beast/base/evolution/tree/TreeScalableTest.java
@@ -1,12 +1,14 @@
 package beast.base.evolution.tree;
 
 import beast.base.inference.ScalableContractTest;
+import beast.base.util.Randomizer;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -25,8 +27,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * </ul>
  *
  * <p>Under the new interval-style {@code Tree.scale}, the contract holds for
- * any positive scale factor on any tree shape (ultrametric or heterochronous),
- * and the move never throws.</p>
+ * any positive scale factor on a tree without sampled ancestors (ultrametric or
+ * heterochronous), and the move never throws.</p>
+ *
+ * <p>Sampled-ancestor trees are the exception. A fake node is pinned to its
+ * direct-ancestor leaf's sampling time and caps the subtree below it, so a large
+ * enough scale factor has nowhere valid to land and is rejected by throwing.
+ * The contract invariants apply to the moves that do not throw; see
+ * {@link Tree#scale(double)}.</p>
  */
 public class TreeScalableTest {
 
@@ -89,6 +97,300 @@ public class TreeScalableTest {
         assertEquals(1.7 * v0, tree.getScalableValue(), Math.abs(1.7 * v0) * 1e-12);
     }
 
+    @Test
+    void contractHoldsForSampledAncestorTreeWithHeadroom() {
+        // Fake root sits far above the subtree below it, so every scale factor
+        // the contract helper tries stays under the ceiling.
+        ScalableContractTest.assertContractAcrossScales(
+                () -> buildSampledAncestorRoomy(),
+                this::assertSameTreeState
+        );
+    }
+
+    @Test
+    void contractHoldsForInternalSampledAncestorWithHeadroom() {
+        // Same, but with the fake node partway down the tree rather than at the root.
+        ScalableContractTest.assertContractAcrossScales(
+                () -> buildInternalSampledAncestorRoomy(),
+                this::assertSameTreeState
+        );
+    }
+
+    @Test
+    void scalePreservesSampledAncestorInvariants() {
+        // A scale that fits: the fake node must not move (its height is the SA's
+        // sampling time), and its child must stay strictly below it.
+        for (double s : new double[] { 0.1, 0.5, 0.9, 1.1, 1.9 }) {
+            Tree tree = buildSampledAncestorTight();
+            tree.scale(s);
+            for (Node n : tree.getNodesAsArray()) {
+                if (n.isFake()) {
+                    assertEquals(5.0, n.getHeight(), 1e-12,
+                            "Fake node height must stay pinned under scale(" + s + ")");
+                    Node child = n.getLeft().isDirectAncestor() ? n.getRight() : n.getLeft();
+                    assertTrue(child.getHeight() < n.getHeight(),
+                            "Child of fake node reached its parent under scale(" + s + ")");
+                }
+            }
+        }
+    }
+
+    @Test
+    void scaleThrowsWhenSampledAncestorCeilingIsBreached() {
+        // buildSampledAncestorTight: child of the fake root ends at 2s + 1, and the
+        // fake root is pinned at 5, so anything from s = 2.0 up has nowhere to land.
+        for (double s : new double[] { 2.0, 2.5, 10.0 }) {
+            Tree tree = buildSampledAncestorTight();
+            assertThrows(IllegalArgumentException.class, () -> tree.scale(s),
+                    "scale(" + s + ") should be rejected: it lifts the fake root's child "
+                    + "to " + (2 * s + 1) + ", at or above the pinned height 5.0");
+        }
+    }
+
+    @Test
+    void rejectedScaleNeverLeavesTheSampledAncestorInvariantBroken() {
+        // The breach is caught during the traversal, so a rejected scale can leave
+        // heights below the fake node already scaled -- callers recover by restoring
+        // state. What must never happen is the throw being skipped and an invalid
+        // tree (child at or above its pinned sampled ancestor) surviving the call.
+        Tree tree = buildSampledAncestorTight();
+        assertThrows(IllegalArgumentException.class, () -> tree.scale(3.0));
+
+        for (Node n : tree.getNodesAsArray()) {
+            if (n.isFake()) {
+                assertEquals(5.0, n.getHeight(), 1e-12,
+                        "Fake node height must stay pinned even on a rejected scale");
+            }
+        }
+    }
+
+    @Test
+    void everyAcceptedScaleHasAnAvailableReverseMove() {
+        // Detailed balance needs the reverse of any move we can make to be a move we
+        // could also have made. Rejecting proposals that breach a sampled-ancestor
+        // ceiling is only sound if it never strands the chain somewhere it cannot
+        // scale back from: whenever scale(s) succeeds, scale(1/s) must succeed too,
+        // land back on the original heights, and contribute the opposite Jacobian.
+        for (double s : new double[] { 0.01, 0.5, 0.9, 1.1, 1.5, 1.9, 1.99 }) {
+            Tree tree = buildSampledAncestorTight();
+            double[] original = new double[tree.getNodesAsArray().length];
+            for (int i = 0; i < original.length; i++) {
+                original[i] = tree.getNodesAsArray()[i].getHeight();
+            }
+
+            double forward = tree.scale(s);
+            double reverse = tree.scale(1.0 / s);
+
+            assertEquals(0.0, forward + reverse, 1e-9,
+                    "log Jacobians of scale(" + s + ") and its reverse should cancel, so "
+                    + "the same number of intervals must be scaled in both directions");
+
+            Node[] nodes = tree.getNodesAsArray();
+            for (int i = 0; i < nodes.length; i++) {
+                assertEquals(original[i], nodes[i].getHeight(),
+                        Math.abs(original[i]) * 1e-9 + 1e-9,
+                        "scale(" + s + ") then scale(1/" + s + ") should return node " + i
+                        + " to its original height");
+            }
+        }
+    }
+
+    @Test
+    void rejectedScaleFactorsAreRejectedFromBothEnds() {
+        // The flip side: a scale factor that is rejected must be rejected wherever the
+        // chain sits, not silently accepted from a state it could not have reached.
+        // Here s = 2.5 breaches the ceiling from the starting state; after shrinking,
+        // the same s becomes legitimately available -- and the state it reaches is one
+        // scale(1/2.5) can leave again.
+        Tree tree = buildSampledAncestorTight();
+        assertThrows(IllegalArgumentException.class, () -> tree.scale(2.5));
+
+        Tree shrunk = buildSampledAncestorTight();
+        shrunk.scale(0.25);
+        double forward = shrunk.scale(2.5);           // now fits under the ceiling
+        double reverse = shrunk.scale(1.0 / 2.5);     // and is reversible
+        assertEquals(0.0, forward + reverse, 1e-9,
+                "a scale that fits must still be exactly reversible");
+    }
+
+    @Test
+    void sampledAncestorDirectlyAboveALeafNeverRejects() {
+        // A sampled ancestor whose other child is a plain leaf: nothing under the
+        // fake node can move, so no scale factor can breach its ceiling.
+        for (double s : new double[] { 0.5, 1.1, 5.0, 100.0 }) {
+            Tree tree = buildSampledAncestorOverLeaf();
+            tree.scale(s);  // should not throw
+        }
+    }
+
+    @Test
+    void shrinkingNeverBreachesSampledAncestorCeiling() {
+        // Scaling down only lowers the subtree, so it can never hit the ceiling
+        // no matter how tight the tree is.
+        for (double s : new double[] { 1e-6, 0.001, 0.5, 0.999 }) {
+            Tree tree = buildSampledAncestorTight();
+            tree.scale(s);  // should not throw
+        }
+    }
+
+    @Test
+    void zeroLengthTipBranchIsTreatedAsASampledAncestorRegardlessOfTreePrior() {
+        // isDirectAncestor()/isFake() are decided purely by height equality and never
+        // consult the tree prior, so a zero-length tip branch reaching the tree any
+        // other way -- a starting Newick, a tip-date move -- gets the sampled-ancestor
+        // treatment too. Documenting that here because it decides what the check below
+        // does outside an FBD analysis.
+        Tree tree = buildZeroLengthTipBranch();
+        Node p = tree.getNodesAsArray()[5];
+        assertTrue(p.isFake(),
+                "a node whose leaf child sits at its own height is 'fake' by height alone");
+
+        // Its height is pinned exactly as a sampled ancestor's would be, so it caps the
+        // subtree below it: X is at 3 with margin 2, so scale(s) puts X at 2s + 1 and
+        // anything from s = 1.5 up would push X through the pinned 4.
+        for (double s : new double[] { 1.5, 2.0, 5.0 }) {
+            Tree t = buildZeroLengthTipBranch();
+            assertThrows(IllegalArgumentException.class, () -> t.scale(s),
+                    "scale(" + s + ") should be rejected rather than silently producing "
+                    + "a child above its parent");
+        }
+
+        // Below the cap it scales normally and stays valid.
+        for (double s : new double[] { 0.1, 0.9, 1.4 }) {
+            Tree t = buildZeroLengthTipBranch();
+            t.scale(s);
+            assertTreeValid(t, "after scale(" + s + ") on a zero-length tip branch");
+        }
+    }
+
+    @Test
+    void zeroLengthInternalBranchStaysZeroAndValid() {
+        // A zero-length branch between two INTERNAL nodes is not "fake" (isDirectAncestor
+        // requires a leaf), so no ceiling applies. It is still frozen: interval scaling
+        // multiplies margins, and a zero margin is absorbing -- s x 0 = 0 for any s. The
+        // branch cannot be reopened by scaling, only by a topology or node-height move.
+        for (double s : new double[] { 0.5, 1.0, 2.0, 10.0 }) {
+            Tree tree = buildZeroLengthInternalBranch();
+            Node p = tree.getNodesAsArray()[5];
+            Node y = tree.getNodesAsArray()[4];
+            assertTrue(!p.isFake(), "an internal zero-length child is not a sampled ancestor");
+
+            tree.scale(s);   // must not throw
+
+            assertEquals(0.0, p.getHeight() - y.getHeight(), 1e-12,
+                    "a zero margin stays zero under scale(" + s + ")");
+            assertTreeValid(tree, "after scale(" + s + ") on a zero-length internal branch");
+        }
+    }
+
+    @Test
+    void aNodeHeightOperatorEscapesBothZeroLengthStates() {
+        // Scale and up-down are MULTIPLICATIVE, so a zero margin is a fixed point:
+        // s x 0 = 0 forever. A node-height operator is ADDITIVE -- it draws a height
+        // uniformly between a node's taller child and its parent -- so it steps off
+        // the zero-length state on the first proposal that touches the node. Under any
+        // continuous tree prior that state has measure zero, so nothing puts it back.
+        //
+        // Both pathologies are therefore transient once such an operator is present:
+        // a fake node caused by a zero-length tip branch has only "up" available (its
+        // taller child sits at its own height), and a zero-length internal branch has
+        // "down" available. Either way the branch opens.
+        // node 3 is leaf D, sitting at its parent P's height -- the zero-length branch
+        assertEscapesZeroLength(buildZeroLengthTipBranch(), 3,
+                "zero-length tip branch (fake node)");
+        // node 4 is internal Y, sitting at its parent P's height
+        assertEscapesZeroLength(buildZeroLengthInternalBranch(), 4,
+                "zero-length internal branch");
+    }
+
+    private void assertEscapesZeroLength(Tree tree, int nodeNr, String what) {
+        Randomizer.setSeed(127);
+        beast.base.evolution.operator.Uniform operator =
+                new beast.base.evolution.operator.Uniform();
+        try {
+            operator.initByName("weight", "1", "tree", tree);
+        } catch (Exception e) {
+            throw new AssertionError("could not set up Uniform operator", e);
+        }
+
+        assertEquals(0.0, tree.getNode(nodeNr).getLength(), 1e-12,
+                what + ": fixture should start with a zero-length branch");
+
+        boolean escaped = false;
+        for (int i = 0; i < 200 && !escaped; i++) {
+            operator.proposal();
+            assertTreeValid(tree, what + ": after Uniform proposal " + i);
+            if (tree.getNode(nodeNr).getLength() > 0.0) {
+                escaped = true;
+            }
+        }
+        assertTrue(escaped,
+                what + ": a node-height operator should open the zero-length branch");
+
+        // and once open, scaling works on it again -- the margin is no longer absorbing
+        double before = tree.getScalableValue();
+        tree.scale(1.5);
+        assertEquals(1.5 * before, tree.getScalableValue(),
+                Math.abs(1.5 * before) * 1e-9 + 1e-9,
+                what + ": scaling should be well behaved once the branch is open");
+    }
+
+    private void assertTreeValid(Tree tree, String when) {
+        for (Node n : tree.getNodesAsArray()) {
+            if (!n.isRoot() && n.getParent().getHeight() < n.getHeight()) {
+                throw new AssertionError("Invalid tree " + when + ": node " + n.getNr()
+                        + " at " + n.getHeight() + " is above parent " + n.getParent().getNr()
+                        + " at " + n.getParent().getHeight());
+            }
+        }
+    }
+
+    /**
+     * No sampled ancestors intended, but leaf D sits exactly at its parent's height:
+     * <pre>
+     *   root (h=10)
+     *    ├── C (leaf, h=0)
+     *    └── P (h=4)          &lt;- "fake" by height alone
+     *         ├── D (leaf, h=4)
+     *         └── X (h=3)
+     *              ├── A (h=0)
+     *              └── B (h=1)
+     * </pre>
+     */
+    private Tree buildZeroLengthTipBranch() {
+        Node a = leaf("A", 0, 0.0);
+        Node b = leaf("B", 1, 1.0);
+        Node c = leaf("C", 2, 0.0);
+        Node d = leaf("D", 3, 4.0);
+        Node x = internal(4, 3.0, a, b);
+        Node p = internal(5, 4.0, d, x);
+        Node root = internal(6, 10.0, c, p);
+        return new Tree(root);
+    }
+
+    /**
+     * Zero-length branch between two internal nodes, which is not a sampled ancestor:
+     * <pre>
+     *   root (h=10)
+     *    ├── C (leaf, h=0)
+     *    └── P (h=4)
+     *         ├── Y (h=4)     &lt;- internal, same height as P
+     *         │    ├── A (h=0)
+     *         │    └── B (h=1)
+     *         └── D (leaf, h=2)
+     * </pre>
+     */
+    private Tree buildZeroLengthInternalBranch() {
+        Node a = leaf("A", 0, 0.0);
+        Node b = leaf("B", 1, 1.0);
+        Node c = leaf("C", 2, 0.0);
+        Node d = leaf("D", 3, 2.0);
+        Node y = internal(4, 4.0, a, b);
+        Node p = internal(5, 4.0, y, d);
+        Node root = internal(6, 10.0, c, p);
+        return new Tree(root);
+    }
+
     /** Ultrametric: leaves A, B, C all at height 0; internal P at 1; root at 2. */
     private Tree buildUltrametric() {
         Node a = leaf("A", 0, 0.0);
@@ -124,6 +426,96 @@ public class TreeScalableTest {
         Node y = internal(4, 2.0, b, c);  // (B, C)
         Node x = internal(5, 3.0, y, a);  // ((B, C), A)
         Node root = internal(6, 4.0, d, x);
+        return new Tree(root);
+    }
+
+    /**
+     * Sampled-ancestor tree with a fake root and plenty of headroom:
+     * <pre>
+     *   root (fake, h=100)
+     *    ├── SA   (leaf, h=100)   direct ancestor: same height as its parent
+     *    └── X    (h=6)
+     *         ├── Y (h=3)
+     *         │    ├── A (h=0)
+     *         │    └── B (h=1)
+     *         └── C (h=2)
+     * </pre>
+     * Margins: Y = 3-1 = 2, X = 6-3 = 3; sum = 5. The fake root contributes none.
+     * Even scale(3.7) lands X at 19.5, well below the pinned 100.
+     */
+    private Tree buildSampledAncestorRoomy() {
+        Node a = leaf("A", 0, 0.0);
+        Node b = leaf("B", 1, 1.0);
+        Node c = leaf("C", 2, 2.0);
+        Node sa = leaf("SA", 3, 100.0);
+        Node y = internal(4, 3.0, a, b);
+        Node x = internal(5, 6.0, y, c);
+        Node root = internal(6, 100.0, sa, x);
+        return new Tree(root);
+    }
+
+    /**
+     * Sampled-ancestor tree with the fake node partway down rather than at the root:
+     * <pre>
+     *   root (h=200)
+     *    ├── C  (leaf, h=0)
+     *    └── F  (fake, h=100)
+     *         ├── SA (leaf, h=100)
+     *         └── X  (h=3)
+     *              ├── A (h=0)
+     *              └── B (h=1)
+     * </pre>
+     * Margins: X = 3-1 = 2, root = 200-100 = 100; sum = 102. F contributes none.
+     */
+    private Tree buildInternalSampledAncestorRoomy() {
+        Node a = leaf("A", 0, 0.0);
+        Node b = leaf("B", 1, 1.0);
+        Node c = leaf("C", 2, 0.0);
+        Node sa = leaf("SA", 3, 100.0);
+        Node x = internal(4, 3.0, a, b);
+        Node f = internal(5, 100.0, sa, x);
+        Node root = internal(6, 200.0, c, f);
+        return new Tree(root);
+    }
+
+    /**
+     * Sampled-ancestor tree with a tight ceiling, for exercising rejection:
+     * <pre>
+     *   root (fake, h=5)
+     *    ├── SA (leaf, h=5)
+     *    └── X  (h=3)
+     *         ├── A (h=0)
+     *         └── B (h=1)
+     * </pre>
+     * X's margin is 3-1 = 2, so scale(s) puts X at 2s + 1. The pinned root is at
+     * 5, so s &lt; 2 fits and s &ge; 2 has nowhere to land.
+     */
+    private Tree buildSampledAncestorTight() {
+        Node a = leaf("A", 0, 0.0);
+        Node b = leaf("B", 1, 1.0);
+        Node sa = leaf("SA", 2, 5.0);
+        Node x = internal(3, 3.0, a, b);
+        Node root = internal(4, 5.0, sa, x);
+        return new Tree(root);
+    }
+
+    /**
+     * Sampled ancestor sitting directly above a single tip:
+     * <pre>
+     *   root (h=10)
+     *    ├── C  (leaf, h=0)
+     *    └── F  (fake, h=5)
+     *         ├── SA (leaf, h=5)
+     *         └── D  (leaf, h=2)
+     * </pre>
+     * Nothing below F can move, so F's ceiling can never be breached.
+     */
+    private Tree buildSampledAncestorOverLeaf() {
+        Node c = leaf("C", 0, 0.0);
+        Node d = leaf("D", 1, 2.0);
+        Node sa = leaf("SA", 2, 5.0);
+        Node f = internal(3, 5.0, sa, d);
+        Node root = internal(4, 10.0, c, f);
         return new Tree(root);
     }
 

--- a/beast-base/src/test/java/beast/base/spec/evolution/operator/SampledAncestorScalingTest.java
+++ b/beast-base/src/test/java/beast/base/spec/evolution/operator/SampledAncestorScalingTest.java
@@ -1,0 +1,180 @@
+package beast.base.spec.evolution.operator;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beast.base.inference.State;
+import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.inference.parameter.RealScalarParam;
+import beast.base.util.Randomizer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Regression tests for interval scaling of sampled-ancestor trees by the tree
+ * operators.
+ *
+ * <p>A fake node's height is pinned to its direct-ancestor leaf's sampling time,
+ * so it caps the subtree below it. Scaling that subtree up through the cap yields
+ * a tree with a child above its parent, which downstream code does not survive:
+ * {@code MRCAPrior.getCommonAncestor} spins forever walking parents and
+ * {@code TreeLikelihood.traverse} blows the stack.</p>
+ *
+ * <p>The scaling recursion existed in three copies &mdash; {@link Node#intervalScale(double)},
+ * {@link UpDownOperator} and {@link IntervalScaleOperator} &mdash; and only the
+ * first was checked, so this went unnoticed. The operators now delegate to
+ * {@code Node.intervalScale}. These tests drive the operators rather than the
+ * recursion so a future private copy is caught here.</p>
+ */
+public class SampledAncestorScalingTest {
+
+    /** How many proposals to draw per operator; scale factors are random. */
+    private static final int PROPOSALS = 2000;
+
+    @Test
+    public void upDownOperatorNeverLeavesSampledAncestorTreeInvalid() throws Exception {
+        Randomizer.setSeed(127);
+
+        Tree tree = buildSampledAncestorTree();
+        RealScalarParam<PositiveReal> rate =
+                new RealScalarParam<>(1.0, PositiveReal.INSTANCE);
+        rate.setID("rate");
+
+        UpDownOperator operator = new UpDownOperator();
+        operator.initByName("weight", "1", "up", tree, "down", rate,
+                "scaleFactor", 0.5, "optimise", false);
+        registerInState(operator, tree, rate);
+
+        assertEveryProposalLeavesTreeValid(operator, tree);
+    }
+
+    @Test
+    public void intervalScaleOperatorNeverLeavesSampledAncestorTreeInvalid() throws Exception {
+        Randomizer.setSeed(127);
+
+        Tree tree = buildSampledAncestorTree();
+        RealScalarParam<PositiveReal> rate =
+                new RealScalarParam<>(1.0, PositiveReal.INSTANCE);
+        rate.setID("rate");
+
+        IntervalScaleOperator operator = new IntervalScaleOperator();
+        operator.initByName("weight", "1", "tree", tree, "down", rate,
+                "scaleFactor", 0.5, "optimise", false);
+        registerInState(operator, tree, rate);
+
+        assertEveryProposalLeavesTreeValid(operator, tree);
+    }
+
+    @Test
+    public void scaleTreeOperatorNeverLeavesSampledAncestorTreeInvalid() throws Exception {
+        Randomizer.setSeed(127);
+
+        Tree tree = buildSampledAncestorTree();
+
+        ScaleTreeOperator operator = new ScaleTreeOperator();
+        operator.initByName("weight", "1", "tree", tree,
+                "scaleFactor", 0.5, "optimise", false);
+        registerInState(operator, tree);
+
+        assertEveryProposalLeavesTreeValid(operator, tree);
+    }
+
+    /**
+     * Draw many proposals and require that the tree is valid after each one,
+     * whether the proposal was accepted or rejected. A rejected proposal may leave
+     * the tree partly scaled (MCMC restores state), so the tree is restored here
+     * too before the next draw.
+     */
+    private void assertEveryProposalLeavesTreeValid(
+            beast.base.inference.Operator operator, Tree tree) {
+
+        int proposed = 0;
+        for (int i = 0; i < PROPOSALS; i++) {
+            double[] before = heightsOf(tree);
+            double logHR = operator.proposal();
+            if (logHR != Double.NEGATIVE_INFINITY) {
+                proposed++;
+                assertTreeValid(tree, "after accepted proposal " + i);
+            }
+            restoreHeights(tree, before);
+        }
+        assertTrue(proposed > 0,
+                "operator rejected every one of " + PROPOSALS + " proposals, so the test "
+                + "never exercised a successful scale");
+    }
+
+    private double[] heightsOf(Tree tree) {
+        Node[] nodes = tree.getNodesAsArray();
+        double[] heights = new double[nodes.length];
+        for (int i = 0; i < nodes.length; i++) {
+            heights[i] = nodes[i].getHeight();
+        }
+        return heights;
+    }
+
+    private void restoreHeights(Tree tree, double[] heights) {
+        Node[] nodes = tree.getNodesAsArray();
+        for (int i = 0; i < nodes.length; i++) {
+            nodes[i].setHeight(heights[i]);
+        }
+    }
+
+    private void assertTreeValid(Tree tree, String when) {
+        for (Node n : tree.getNodesAsArray()) {
+            if (!n.isRoot() && n.getParent().getHeight() < n.getHeight()) {
+                fail("Invalid tree " + when + ": node " + n.getNr() + " at height "
+                        + n.getHeight() + " is above its parent " + n.getParent().getNr()
+                        + " at height " + n.getParent().getHeight());
+            }
+        }
+    }
+
+    /** Operators need their StateNodes owned by a State before proposal() works. */
+    private void registerInState(beast.base.inference.Operator operator,
+                                 beast.base.inference.StateNode... nodes) throws Exception {
+        State state = new State();
+        state.initByName("stateNode", java.util.Arrays.asList(nodes));
+        state.initialise();
+        state.setPosterior(new beast.base.inference.CompoundDistribution());
+    }
+
+    /**
+     * Sampled-ancestor tree with a tight ceiling:
+     * <pre>
+     *   root (fake, h=5)
+     *    ├── SA (leaf, h=5)      direct ancestor, pins the root
+     *    └── X  (h=3)
+     *         ├── A (h=0)
+     *         └── B (h=1)
+     * </pre>
+     * X's margin is 2, so a scale of s puts X at 2s + 1; anything from s = 2 up
+     * would push X through the pinned root at 5.
+     */
+    private Tree buildSampledAncestorTree() {
+        Node a = leaf("A", 0, 0.0);
+        Node b = leaf("B", 1, 1.0);
+        Node sa = leaf("SA", 2, 5.0);
+        Node x = internal(3, 3.0, a, b);
+        Node root = internal(4, 5.0, sa, x);
+        Tree tree = new Tree(root);
+        tree.setID("tree");
+        return tree;
+    }
+
+    private Node leaf(String id, int nr, double height) {
+        Node n = new Node(id);
+        n.setNr(nr);
+        n.setHeight(height);
+        return n;
+    }
+
+    private Node internal(int nr, double height, Node left, Node right) {
+        Node n = new Node();
+        n.setNr(nr);
+        n.setHeight(height);
+        n.addChild(left);
+        n.addChild(right);
+        return n;
+    }
+}


### PR DESCRIPTION
## Summary

Interval scaling could lift a node through its own sampled ancestor, leaving a tree with a child above its parent. Downstream code does not survive that state: `MRCAPrior.getCommonAncestor` spins forever walking parent pointers, and `TreeLikelihood.traverse` blows the stack.

A fake node's height is pinned to its direct-ancestor leaf's sampling time, so it cannot move and acts as a fixed ceiling on the subtree below it. The room between that ceiling and the fixed leaves underneath is finite, so a large enough scale factor has nowhere valid to land. `Node.intervalScale` now throws `IllegalArgumentException` — the rejection signal the `Scalable` contract already specifies, and which every scale operator already catches.

The recursion existed in **three copies** and only `Node.intervalScale` was checked, which is why this survived. `UpDownOperator` and `IntervalScaleOperator` now delegate to it instead of keeping private copies. `IntervalScaleOperator.proposal` also gained the try/catch it was missing, so a rejection no longer kills the chain.

Closes #78.

## Impact on analyses without sampled ancestors

None measurable. The check sits inside `if (isFake())`, a branch these trees never enter, and that call was already there.

`Tree.scale` microbenchmark, this branch vs master, best of 3 runs:

| tips | master | this branch |
|---|---|---|
| 128 | 1977.5 ns/call | 1907.4 ns/call |
| 1024 | 20558.2 ns/call | 20399.9 ns/call |
| 4096 | 82276.7 ns/call | 81863.0 ns/call |

Re-running with alternating order flipped the sign, so this is noise under 1%.

Results are bit-identical: reproducing the deleted `resampleNodeHeight` verbatim and comparing against `Node.intervalScale` over 500 random trees (ultrametric and heterochronous, 4–200 tips, scale factors 0.2–4.2) matches 102,188 node heights on `doubleToLongBits`, with identical dof counts.

One behavioural delta worth review: the deleted copies used `node.setHeight()`, which also marks both children dirty, whereas `Node.intervalScale` marks only the node itself. This is safe because all four likelihood implementations (legacy and spec, `TreeLikelihood` and `BeagleTreeLikelihood`) gate recomputation on `update != Tree.IS_CLEAN || branchTime != m_branchLengths[nodeIndex]`, so a changed branch length is picked up regardless of the flag. `Node.isDirty()` has no other consumers in core, and `ScaleOperator`/`ScaleTreeOperator` already went through `intervalScale`, so this makes `UpDownOperator` consistent with the path already in production.

## Hastings ratio

Rejecting is the correct acceptance probability rather than an approximation: the invalid tree is outside the model's support, so π = 0 and α = 0. Two properties make that sound, both covered by tests:

- **The reverse move always exists.** Only upward moves can breach a ceiling, so `scale(1/s)` can never fail, and interval scaling is exactly invertible (leaf and fake-node heights are never touched).
- **The Jacobians match.** `dof` counts non-fake internal nodes; scaling changes no topology, moves no fake node, and cannot create a new zero-length tip branch, so the fake-node set is invariant.

Rejections feed `logAlpha = -Infinity` into `calcDelta`, where `Math.exp(Math.min(logAlpha, 0))` is 0 — finite, no NaN — giving Robbins-Monro the intended downward nudge on the scale factor.

## Zero-length branches outside an FBD analysis

`isFake()`/`isDirectAncestor()` are decided purely by height equality and never consult the tree prior, so this applies to any analysis. Both cases are now covered by tests:

- **Zero-length tip branch** gets the sampled-ancestor treatment regardless of the prior. Previously scaling through it silently produced an invalid tree; it is now rejected.
- **Zero-length internal branch** is not fake, so no ceiling applies. It is still frozen, because interval scaling is multiplicative and a zero margin is absorbing — unchanged by this PR.

Both are transient in practice: a node-height operator is additive and steps off the state on the first proposal that touches the node, after which nothing returns to it (measure zero under a continuous prior). TreeParser binarizing a polytomy produces zero-length *internal* edges only, so consensus and constraint starting trees never reach the ceiling path.

## Test plan

- [x] `TreeScalableTest` 5 → 17 tests; new `SampledAncestorScalingTest` adds 3, driving all three operators over 2000 proposals each and asserting the tree is never left invalid
- [x] Reverting the three main-source files fails 7 of the 15 new tests (4 in `TreeScalableTest`, all 3 in `SampledAncestorScalingTest`); the remaining 8 cover behaviour this PR preserves rather than changes
- [x] beast-base suite on a clean build: 477 tests, 0 failures, 3 skipped
- [x] sampled-ancestors `bears.xml` and `bears_ranges.xml` run 200k states to completion; both previously hung or crashed at sample 0
- [ ] Not verified: downstream packages that call `Tree.scale` from initialisation code without a try/catch would abort rather than reject if handed a tree with sampled ancestors. `BEASTLabs.TreeScaleOperator` catches and is fine; `starbeast3.StarBeastStartState` has three uncaught call sites, though species trees are not SA trees. Both still use the pre-#20 `int` return signature and do not compile against current beast3 regardless.

## Follow-ups, not in this PR

- `sampled-ancestors` needs its example XMLs repaired and its `beast.version` bumped once this is released; its examples currently fail against beta5 and beta7 for exactly this bug.
- `Tree.allowSampledAncestors()` has had no callers since the Constraints PR that used it was reverted in fc77f3c. BEAST infers "sampled ancestor" from exact height equality with no flag, which is what makes the zero-length-tip case above ambiguous.
