### PR TITLE
fix beauti clone bug and revive CloneTest #130

### DIFF
--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
@@ -2363,9 +2363,21 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
                     if (input.get() != null) {
                         if (input.get() instanceof List) {
                             // handle lists
-                            //((List)copy.getInput(input.getName())).clear();
-                            for (Object o : (List<?>) input.get()) {
-                                if (o instanceof BEASTInterface) {
+                            List<?> sourceList = (List<?>) input.get();
+                            boolean isPrimitiveList = sourceList.isEmpty() || !(sourceList.get(0) instanceof BEASTInterface);
+                            if (isPrimitiveList) {
+                                // list of primitive values (e.g. Parameter "value" input): replace the
+                                // copy's list wholesale instead of appending per source element, since
+                                // Input.setValue(List, ...) appends *all* elements of the given list --
+                                // iterating per element here would append the whole source list once
+                                // per element, e.g. turning a dimension-4 freqParameter into 16.
+                                Object dest = copy.getInput(input.getName()).get();
+                                if (dest instanceof List) {
+                                    ((List<?>) dest).clear();
+                                }
+                                copy.setInputValue(input.getName(), input.get());
+                            } else {
+                                for (Object o : sourceList) {
                                     BEASTInterface value = getCopyValue((BEASTInterface) o, copySet, oldContext, newContext, doc);
                                     // make sure it is not already in the list
                                     Object o2 = copy.getInput(input.getName()).get();
@@ -2383,14 +2395,6 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
                                         // add to the list
                                         copy.setInputValue(input.getName(), value);
                                     }
-                                } else {
-                                    // it is a primitive value
-                                    if (copy instanceof Parameter.Base && input.getName().equals("value")) {
-                                        //	// prevent appending to parameter values
-                                        Parameter.Base<?> p = ((Parameter.Base<?>) copy);
-                                        ((List<?>) p.valuesInput.get()).clear();
-                                    }
-                                    copy.setInputValue(input.getName(), input.get());
                                 }
                             }
                         } else if (input.get() instanceof BEASTInterface) {

--- a/beast-fx/src/test/java/test/beastfx/app/beauti/CloneTest.java
+++ b/beast-fx/src/test/java/test/beastfx/app/beauti/CloneTest.java
@@ -1,11 +1,10 @@
 package test.beastfx.app.beauti;
 
 
-
-
-
-import java.io.File;
-
+import beastfx.app.beauti.BeautiTabPane;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.ListView;
+import javafx.stage.Stage;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,10 +12,7 @@ import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 
-import beastfx.app.beauti.BeautiTabPane;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.ListView;
-import javafx.stage.Stage;
+import java.io.File;
 
 @ExtendWith(ApplicationExtension.class)
 public class CloneTest extends BeautiBase {
@@ -35,7 +31,6 @@ public class CloneTest extends BeautiBase {
 	}
 
 
- 	@Disabled("SimplexParam validation fails when freqParameter is cloned across partitions (dimension mismatch)")
  	@Test
  	public void simpleSiteModelCloneTest(FxRobot robot) throws Exception {
         warning("0. Load primate-mtDNA.nex");


### PR DESCRIPTION
Fixes #130

## Summary

Cloning a site model (e.g. HKY, GTR) across partitions in BEAUti inflated the cloned
`freqParameter`'s dimension from N to N² (4 → 16 for nucleotide frequencies), producing an
XML file that BEAST could not run.

## Bug location

`BeautiDoc.deepCopyPlugin()` in `beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java`
(~line 2364-2395). When copying a `List`-valued input, the code iterated once per **element**
of the source list, but on each iteration called `copy.setInputValue(input.getName(), input.get())`
— passing the *entire* source list, not the current element. `Input.setValue()` appends all
elements of a given list to the destination (`Input.java:452-461`), so this would over-fill the
copy on every pass.

This was previously masked by a special case: if `copy instanceof Parameter.Base`, the destination
list was `clear()`-ed before each `setInputValue` call, so each pass reset-then-refilled to the
correct size. But `Parameter.Base` (`beast.base.inference.parameter.Parameter.Base`) is BEAST3's
now-`@Deprecated` legacy parameter class. The new spec-based parameters used by BEAUti's
site-model templates — `SimplexParam` → `RealVectorParam` → `KeyVectorParam` → `StateNode` — no
longer extend it. So `copy instanceof Parameter.Base` is `false` for a `SimplexParam` (e.g.
`freqParameter`), the `clear()` never runs, and the whole source list gets appended once per
source element: a dimension-4 list appends 4 times → 16 elements.

The bug was already documented by a disabled regression test:
`beast-fx/src/test/java/test/beastfx/app/beauti/CloneTest.java` —
`@Disabled("SimplexParam validation fails when freqParameter is cloned across partitions (dimension mismatch)")`.

## Fix

Stop iterating per-element for primitive-valued lists (the loop never used the per-element
value `o` anyway — it always re-set the whole list). Instead, detect once whether the source
list holds primitives (vs. `BEASTInterface` sub-objects, which still need per-element dedup
handling), clear the destination list a single time, and set it once:

```java
if (input.get() instanceof List) {
    List<?> sourceList = (List<?>) input.get();
    boolean isPrimitiveList = sourceList.isEmpty() || !(sourceList.get(0) instanceof BEASTInterface);
    if (isPrimitiveList) {
        // replace the copy's list wholesale instead of appending per source element
        Object dest = copy.getInput(input.getName()).get();
        if (dest instanceof List) {
            ((List<?>) dest).clear();
        }
        copy.setInputValue(input.getName(), input.get());
    } else {
        for (Object o : sourceList) {
            // ... unchanged BEASTInterface element handling
        }
    }
}
```

This removes the stale `Parameter.Base` cast, so it works uniformly for legacy and new-style
parameters, and does the clear-then-set exactly once instead of once per element (also
avoiding the redundant O(n²) work of the old code path).

## Changes

- `BeautiDoc.deepCopyPlugin()`: replace the per-element primitive-value copy (gated on the
  stale `Parameter.Base` check) with a single wholesale list replace.
- `CloneTest.simpleSiteModelCloneTest`: re-enable (was `@Disabled` pending this fix).

