### PR TITLE
Widen RateStatistic domain to NonNegativeReal

### DIFF
--- a/beast-base/src/main/java/beast/base/spec/evolution/RateStatistic.java
+++ b/beast-base/src/main/java/beast/base/spec/evolution/RateStatistic.java
@@ -33,7 +33,7 @@ import beast.base.core.Input.Validate;
 import beast.base.core.Loggable;
 import beast.base.evolution.tree.Node;
 import beast.base.evolution.tree.Tree;
-import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.domain.NonNegativeReal;
 import beast.base.spec.evolution.branchratemodel.Base;
 import beast.base.spec.evolution.likelihood.GenericTreeLikelihood;
 import beast.base.spec.type.RealVector;
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 
 @Description("A statistic that tracks the mean, variance and coefficent of variation of rates. " +
         "It has three dimensions, one for each statistic.")
-public class RateStatistic extends BEASTObject implements Loggable, RealVector<PositiveReal> {
+public class RateStatistic extends BEASTObject implements Loggable, RealVector<NonNegativeReal> {
 	
     final public Input<GenericTreeLikelihood> likelihoodInput = new Input<>("treeLikelihood", "TreeLikelihood containing branch rate model that provides rates for a tree");
     final public Input<Base> branchRateModelInput = new Input<>("branchratemodel", "model that provides rates for a tree", Validate.XOR, likelihoodInput);
@@ -180,9 +180,16 @@ public class RateStatistic extends BEASTObject implements Loggable, RealVector<P
         return Arrays.stream(calcValues()).boxed().collect(Collectors.toList());
     }
 
+    /**
+     * Non-negative rather than positive: the variance and the coefficient of
+     * variation are exactly 0 whenever every branch carries the same rate, which
+     * is the normal state of affairs under a strict clock. {@code PositiveReal}
+     * excludes 0 ({@code lowerInclusive()} is false), so declaring it here makes
+     * {@link #isValid()} report false for a perfectly ordinary analysis.
+     */
     @Override
-    public PositiveReal getDomain() {
-        return PositiveReal.INSTANCE;
+    public NonNegativeReal getDomain() {
+        return NonNegativeReal.INSTANCE;
     }
 
     /**

--- a/beast-base/src/test/java/beast/base/spec/evolution/RateStatisticTest.java
+++ b/beast-base/src/test/java/beast/base/spec/evolution/RateStatisticTest.java
@@ -1,0 +1,122 @@
+package beast.base.spec.evolution;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beast.base.spec.evolution.branchratemodel.Base;
+import beast.base.spec.evolution.branchratemodel.StrictClockModel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the spec {@link RateStatistic}, in particular the domain it declares.
+ *
+ * <p>The statistic exposes three elements — mean, variance, coefficient of
+ * variation — through one {@code RealVector} domain, so that domain has to admit
+ * every value all three can legitimately take. Variance and coefficient of
+ * variation are exactly 0 whenever the branches share a rate, which is the
+ * ordinary state of affairs under a strict clock, so the domain has to include
+ * zero.</p>
+ */
+public class RateStatisticTest {
+
+    /** Rates keyed off node number, so each branch can differ. */
+    private static class FixedRates extends Base {
+        private final double[] rates;
+        FixedRates(double... rates) { this.rates = rates; }
+        @Override public void initAndValidate() {}
+        @Override public double getRateForBranch(Node node) { return rates[node.getNr()]; }
+    }
+
+    @Test
+    public void strictClockLeavesVarianceAtZeroAndStillValidates() throws Exception {
+        // Every branch shares a rate, so variance and coefficient of variation are
+        // exactly 0. PositiveReal excludes 0, so declaring it here made isValid()
+        // report false for a perfectly ordinary strict-clock analysis.
+        RateStatistic rs = statisticOn(new StrictClockModel());
+
+        double[] values = rs.calcValues();
+        assertEquals(0.0, values[1], 0.0, "strict clock should give zero variance");
+        assertEquals(0.0, values[2], 0.0, "strict clock should give zero coefficient of variation");
+
+        assertTrue(rs.isValid(0.0), "the declared domain must admit zero");
+        assertTrue(rs.isValid(), "a strict-clock RateStatistic must validate");
+    }
+
+    @Test
+    public void domainStillRejectsNegatives() throws Exception {
+        // Widening to NonNegativeReal must not weaken the domain to plain Real:
+        // none of the three statistics can be negative.
+        RateStatistic rs = statisticOn(new StrictClockModel());
+        assertFalse(rs.isValid(-1.0), "negative values are not in the domain");
+    }
+
+    @Test
+    public void varyingRatesProduceTheDocumentedStatistics() throws Exception {
+        // 3 tips: A, B at height 0, C at height 0; P at 1 joins A and B; root at 2.
+        // Node numbering: A=0, B=1, C=2, P=3, root=4. The root has no branch, so
+        // four branches are measured: A, B, C (external) and P (internal).
+        //   branch lengths: A=1, B=1, C=2, P=1
+        //   rates:          A=1, B=2, C=3, P=4  (root's entry is never read)
+        RateStatistic rs = statisticOn(new FixedRates(1.0, 2.0, 3.0, 4.0, 99.0));
+
+        double[] values = rs.calcValues();
+        // mean is branch-length weighted: (1*1 + 2*1 + 3*2 + 4*1) / (1+1+2+1)
+        assertEquals((1.0 + 2.0 + 6.0 + 4.0) / 5.0, values[0], 1e-12,
+                "mean should be weighted by branch length");
+        // variance and cv are unweighted over the same four rates
+        double unweightedMean = (1.0 + 2.0 + 3.0 + 4.0) / 4.0;
+        double sumSq = 0.0;
+        for (double r : new double[] { 1.0, 2.0, 3.0, 4.0 }) {
+            sumSq += (r - unweightedMean) * (r - unweightedMean);
+        }
+        double expectedVariance = sumSq / 3.0;   // DiscreteStatistics uses count - 1
+        assertEquals(expectedVariance, values[1], 1e-12);
+        assertEquals(Math.sqrt(expectedVariance) / unweightedMean, values[2], 1e-12);
+
+        assertTrue(rs.isValid(), "varying rates should validate too");
+    }
+
+    @Test
+    public void getRejectsOutOfRangeIndices() throws Exception {
+        // The legacy getArrayValue(dim) guarded with `dim > 3`, so dim == 3 fell
+        // through to an ArrayIndexOutOfBoundsException and negatives went unchecked.
+        RateStatistic rs = statisticOn(new StrictClockModel());
+        assertEquals(3, rs.size());
+        assertThrows(IllegalArgumentException.class, () -> rs.get(3));
+        assertThrows(IllegalArgumentException.class, () -> rs.get(-1));
+    }
+
+    /** Three-tip ultrametric tree wired to the given branch rate model. */
+    private RateStatistic statisticOn(Base branchRateModel) throws Exception {
+        Node a = leaf("A", 0);
+        Node b = leaf("B", 1);
+        Node c = leaf("C", 2);
+        Node p = internal(3, 1.0, a, b);
+        Tree tree = new Tree(internal(4, 2.0, p, c));
+
+        branchRateModel.initAndValidate();
+        RateStatistic rs = new RateStatistic();
+        rs.initByName("tree", tree, "branchratemodel", branchRateModel);
+        return rs;
+    }
+
+    private Node leaf(String id, int nr) {
+        Node n = new Node(id);
+        n.setNr(nr);
+        n.setHeight(0.0);
+        return n;
+    }
+
+    private Node internal(int nr, double height, Node left, Node right) {
+        Node n = new Node();
+        n.setNr(nr);
+        n.setHeight(height);
+        n.addChild(left);
+        n.addChild(right);
+        return n;
+    }
+}


### PR DESCRIPTION
Targets `RateStatistic` (#120) rather than `master`, so it can go in before that PR merges.

## The problem

The new spec `RateStatistic` declares `RealVector<PositiveReal>`. It exposes three elements through that one domain — mean, variance, coefficient of variation — so the domain has to admit every value all three can take.

Variance and coefficient of variation are exactly 0 whenever every branch carries the same rate. That is not a corner case: it is the ordinary state of affairs under a strict clock. `PositiveReal` excludes 0 (`lowerInclusive()` returns false), so:

```
strict clock: mean=1.0 variance=0.0 cv=0.0
declared domain      : PositiveReal  (lower=0.0, lowerInclusive=false)
isValid(variance=0.0): false
isValid() over all 3 : false
```

Nothing in `parser`, `core` or `inference` calls `isValid()` today, so this is latent rather than a crash. But the spec migration plainly intends that enforcement, and by the time it arrives the class will have shipped in a release and been adopted — so it is much cheaper to correct the type parameter now than to change it under users later.

## The change

`PositiveReal` → `NonNegativeReal`, plus a comment on `getDomain()` recording why, so it does not get tightened back.

`NonNegativeReal` still rejects negatives, which none of the three statistics can be — the domain is widened by exactly the one value that was wrongly excluded, not loosened to plain `Real`.

For what it is worth, the sibling migrated class in the same package, `beast.base.spec.evolution.Sum`, declares `RealScalar<Real>` rather than a tighter positive domain, so declaring only what is actually guaranteed looks like the established convention.

## Tests

Adds `RateStatisticTest` with four cases:

- the strict-clock case — variance and cv are 0 and `isValid()` holds. This one **fails against `PositiveReal`** with "the declared domain must admit zero", so it pins the fix down.
- negatives are still rejected, i.e. the domain was not weakened past what is meaningful.
- weighted mean and unweighted variance for varying rates, checked against hand-computed values, which also documents that the mean is branch-length weighted while the variance is not.
- the index guard on `get()`. Worth locking in: the legacy `getArrayValue(dim)` guarded with `dim > 3`, so `dim == 3` fell through to an `ArrayIndexOutOfBoundsException` and negatives went unchecked. #120 quietly fixes that and the test records it.

beast-base suite on this branch: 462 tests, 0 failures.