### PR TITLE
Update BEAUti fxtemplates to BEAST3 spec classes

### DIFF
--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/ClockModels.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/ClockModels.xml
@@ -1,5 +1,5 @@
 
-<beast version='2.0'
+<beast version='2.8'
        namespace='beastfx.app.beauti:beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.branchratemodel:beast.base.evolution.speciation:beast.base.evolution.tree.coalescent:beast.base.util:beast.base.math:beast.evolution.nuc:beast.base.evolution.operator:beast.base.inference.operator:beast.base.evolution.sitemodel:beast.base.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.evolution:beast.base.inference.distribution'>
 
 

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
@@ -1,4 +1,4 @@
-<beast version='2.0'
+<beast version='2.8'
        namespace='beastfx.app.beauti:beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.branchratemodel:beast.base.evolution.speciation:beast.base.evolution.tree.coalescent:beast.base.util:beast.base.math:beast.evolution.nuc:beast.base.evolution.operator:beast.base.inference.operator:beast.base.evolution.sitemodel:beast.base.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.evolution:beast.base.inference.distribution'>
 
 
@@ -201,14 +201,14 @@
         </subtemplate>
 
         <!-- Dirichlet -->
-        <subtemplate id='Dirichlet' class='beast.base.inference.distribution.Dirichlet' mainid='[top]'
+        <subtemplate id='Dirichlet' class='beast.base.spec.inference.distribution.Dirichlet' mainid='[top]'
             hmc='
             Dirichlet/alpha/=ParametricDistributions/Dirichlet/mean/,
             Dirichlet/offset/=ParametricDistributions/Dirichlet/offset/'>
             <![CDATA[
-			<distr spec="beast.base.inference.distribution.Dirichlet">
-                <parameter spec="parameter.RealParameter" estimate="false" name="alpha">1.0</parameter>
-            </distr> 
+			<distr spec="beast.base.spec.inference.distribution.Dirichlet">
+                <alpha spec="beast.base.spec.inference.parameter.RealVectorParam" domain="PositiveReal" estimate="false">1.0</alpha>
+            </distr>
 ]]>
         </subtemplate>
 

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/Standard.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/Standard.xml
@@ -1,28 +1,43 @@
-<beast version='2.0'
+<beast version='2.8'
        namespace='beastfx.app.beauti:beastfx.app.inputeditor:beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.branchratemodel:beast.base.evolution.speciation:beast.base.evolution.tree.coalescent:beast.base.util:beast.base.math:beast.evolution.nuc:beast.base.evolution.operator:beast.base.inference.operator:beast.base.spec.evolution.sitemodel:beast.base.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.evolution:beast.base.inference.distribution'
 	templateinfo='template for standard phylogenetic analysis,&lt;br> supporting tip-date analysis and calibrations'>
 
-<map name='connect' reserved='true'>beastfx.app.inputeditor.BeautiConnector</map>
-<map name='subtemplate' reserved='true'>beastfx.app.inputeditor.BeautiSubTemplate</map>
-<map name='Uniform'>beast.base.inference.distribution.Uniform</map>
-<map name='Normal'>beast.base.inference.distribution.Normal</map>
-<map name='OneOnX'>beast.base.inference.distribution.OneOnX</map>
-<map name='LogNormal'>beast.base.inference.distribution.LogNormalDistributionModel</map>
-<map name='Exponential'>beast.base.inference.distribution.Exponential</map>
-<map name='Gamma'>beast.base.inference.distribution.Gamma</map>
-<map name='Beta'>beast.base.inference.distribution.Beta</map>
-<map name='LaplaceDistribution'>beast.base.inference.distribution.LaplaceDistribution</map>
-<map name='InverseGamma'>beast.base.inference.distribution.InverseGamma</map>
-<map name='prior'>beast.base.inference.distribution.Prior</map>
+    <map name='connect' reserved='true'>beastfx.app.inputeditor.BeautiConnector</map>
+    <map name='subtemplate' reserved='true'>beastfx.app.inputeditor.BeautiSubTemplate</map>
+
+    <!-- Univariate distribution, OneOnX is removed -->
+    <map name='Bernoulli'>beast.base.spec.inference.distribution.Bernoulli</map>
+    <map name='Beta'>beast.base.spec.inference.distribution.Beta</map>
+    <map name='Cauchy'>beast.base.spec.inference.distribution.Cauchy</map>
+    <map name='ChiSquare'>beast.base.spec.inference.distribution.ChiSquare</map>
+    <map name='Exponential'>beast.base.spec.inference.distribution.Exponential</map>
+    <map name='Gamma'>beast.base.spec.inference.distribution.Gamma</map>
+    <map name='GammaMean'>beast.base.spec.inference.distribution.GammaMean</map>
+    <map name='IntUniform'>beast.base.spec.inference.distribution.IntUniform</map>
+    <map name='InverseGamma'>beast.base.spec.inference.distribution.InverseGamma</map>
+    <map name='LaplaceDistribution'>beast.base.spec.inference.distribution.Laplace</map>
+    <map name='LogNormal'>beast.base.spec.inference.distribution.LogNormal</map>
+    <map name='LogUniform'>beast.base.spec.inference.distribution.LogUniform</map>
+    <map name='Normal'>beast.base.spec.inference.distribution.Normal</map>
+    <map name='Uniform'>beast.base.spec.inference.distribution.Uniform</map>
+    <map name='Poisson'>beast.base.spec.inference.distribution.Poisson</map>
+    <!-- Multivariate distribution   -->
+    <map name='Dirichlet'>beast.base.spec.inference.distribution.Dirichlet</map>
+    <map name='IID'>beast.base.spec.inference.distribution.IID</map>
+    <!-- Conditional distribution  -->
+    <map name='OffsetInt'>beast.base.spec.inference.distribution.OffsetInt</map>
+    <map name='OffsetReal'>beast.base.spec.inference.distribution.OffsetReal</map>
+    <map name='TruncatedInt'>beast.base.spec.inference.distribution.TruncatedInt</map>
+    <map name='TruncatedReal'>beast.base.spec.inference.distribution.TruncatedReal</map>
 
     <beauticonfig spec='BeautiConfig'
         inputLabelMap='beast.base.inference.MCMC.operator=Operators,
 	        beast.base.inference.MCMC.logger=Loggers,
 			beast.base.spec.evolution.sitemodel.SiteModel.mutationRate=Substitution Rate,
-			beast.base.evolution.speciation.YuleModel.birthDiffRate=Birth Rate,
-			beast.base.evolution.branchratemodel.UCRelaxedClockModel.clock.rate=Mean clock rate,
-			beast.base.evolution.branchratemodel.StrictClockModel.clock.rate=Mean clock rate,
-			beast.base.evolution.branchratemodel.RandomLocalClockModel.clock.rate=Mean clock rate
+			beast.base.spec.evolution.speciation.YuleModel.birthDiffRate=Birth Rate,
+			beast.base.spec.evolution.branchratemodel.UCRelaxedClockModel.clock.rate=Mean clock rate
+			beast.base.spec.evolution.branchratemodel.StrictClockModel.clock.rate=Mean clock rate,
+			beast.base.spec.evolution.branchratemodel.RandomLocalClockModel.clock.rate=Mean clock rate
 			'
         inlinePlugins ='beast.base.inference.MCMC.distribution,
             beast.base.spec.evolution.sitemodel.SiteModel.substModel,
@@ -87,22 +102,18 @@
 	        beast.base.spec.evolution.substitutionmodel.MTREV.rates,
 	        beast.base.spec.evolution.substitutionmodel.MTREV.frequencies,
 	        beast.base.spec.evolution.substitutionmodel.GTR.rates,
-	        beast.base.evolution.substitutionmodel.JukesCantor.frequencies,
+	        beast.base.spec.evolution.substitutionmodel.JukesCantor.frequencies,
             beast.base.inference.distribution.Prior.x,
             beast.base.spec.evolution.tree.MRCAPrior.tree,
             beast.base.spec.evolution.tree.MRCAPrior.monophyletic,
             beast.base.spec.evolution.tree.MRCAPrior.taxonset,
-            beast.base.evolution.tree.MRCAPrior.tree,
-            beast.base.evolution.tree.MRCAPrior.monophyletic,
-            beast.base.evolution.tree.MRCAPrior.taxonset,
-            beast.base.evolution.branchratemodel.UCRelaxedClockModel.tree,
-            beast.base.evolution.branchratemodel.UCRelaxedClockModel.rateCategories,
-			beast.base.evolution.branchratemodel.UCRelaxedClockModel.distr,
+            beast.base.spec.evolution.branchratemodel.UCRelaxedClockModel.tree,
+            beast.base.spec.evolution.branchratemodel.UCRelaxedClockModel.rateCategories,
+			beast.base.spec.evolution.branchratemodel.UCRelaxedClockModel.distr,
             beast.base.spec.evolution.branchratemodel.RandomLocalClockModel.tree,
             beast.base.spec.evolution.branchratemodel.RandomLocalClockModel.meanRate,
             beast.base.spec.evolution.branchratemodel.RandomLocalClockModel.indicators,
             beast.base.spec.evolution.operator.ScaleOperator.indicator,
-            beast.base.evolution.operator.ScaleOperator.indicator,
 	        beast.base.inference.Operator.weight,
             beast.base.inference.Logger.model,
             beast.base.spec.evolution.tree.coalescent.BayesianSkyline.treeIntervals,
@@ -293,8 +304,8 @@ ClusterTree/clusterType/,
             <!--plugin spec='beast.base.spec.evolution.tree.coalescent.RandomTree' id='RandomTree.t:$(n)' estimate='false' trait='@datetrait.$(n)' initial='@Tree.t:$(n)'-->
             <plugin spec='beast.base.spec.evolution.tree.coalescent.RandomTree' id='RandomTree.t:$(n)' estimate='false' initial='@Tree.t:$(n)'>
                 <taxa idref='data'/>
-                <populationModel id='ConstantPopulation0.t:$(n)' spec='ConstantPopulation'>
-            		<popSize id='randomPopSize.t:$(n)' spec='parameter.RealParameter' value='1'/>
+                <populationModel id='ConstantPopulation0.t:$(n)' spec='beast.base.spec.evolution.tree.coalescent.ConstantPopulation'>
+            		<popSize id='randomPopSize.t:$(n)' spec='beast.base.spec.inference.parameter.RealScalarParam' domain='PositiveReal' value='1'/>
 	            </populationModel>
             </plugin>
 
@@ -475,10 +486,10 @@ ClusterTree/clusterType/,
 
         <subtemplate id='RandomTree' class='beast.base.spec.evolution.tree.coalescent.RandomTree' mainid='RandomTree.t:$(n)'>
 <![CDATA[
-            <tree spec='beast.base.evolution.tree.coalescent.RandomTree' id='RandomTree.t:$(n)' estimate='false' initial="@Tree.t:$(n)">
+            <tree spec='beast.base.spec.evolution.tree.coalescent.RandomTree' id='RandomTree.t:$(n)' estimate='false' initial="@Tree.t:$(n)">
                 <taxa idref='data'/>
-                <populationModel id='ConstantPopulation0.t:$(n)' spec='ConstantPopulation'>
-            		<popSize id='randomPopSize.t:$(n)' spec='parameter.RealParameter' value='1'/>
+                <populationModel id='ConstantPopulation0.t:$(n)' spec='beast.base.spec.evolution.tree.coalescent.ConstantPopulation'>
+            		<popSize id='randomPopSize.t:$(n)' spec='beast.base.spec.inference.parameter.RealScalarParam' domain='PositiveReal' value='1'/>
 	            </populationModel>
             </tree>
 ]]>

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/SubstModels.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/SubstModels.xml
@@ -1,4 +1,4 @@
-<beast version='2.0'
+<beast version='2.8'
        namespace='beastfx.app.beauti:beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.branchratemodel:beast.base.evolution.speciation:beast.base.evolution.tree.coalescent:beast.base.util:beast.base.math:beast.evolution.nuc:beast.base.evolution.operator:beast.base.spec.inference.operator:beast.base.spec.evolution.sitemodel:beast.base.spec.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.evolution:beast.base.inference.distribution'>
 
        
@@ -109,7 +109,7 @@ MutationRatePrior/index/=Priors/MutationRatePrior/
 
         <!-- substitution models -->
         <!-- JC69 substitution model -->
-        <subtemplate id='JC69' class='beast.base.evolution.substitutionmodel.JukesCantor' mainid='JC69.s:$(n)'>
+        <subtemplate id='JC69' class='beast.base.spec.evolution.substitutionmodel.JukesCantor' mainid='JC69.s:$(n)'>
             <![CDATA[
         <plugin spec='JukesCantor' id='JC69.s:$(n)'/>
 ]]>

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/TreePriors.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/TreePriors.xml
@@ -1,4 +1,4 @@
-<beast version='2.0'
+<beast version='2.8'
        namespace='beastfx.app.beauti:beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.branchratemodel:beast.base.evolution.speciation:beast.base.evolution.tree.coalescent:beast.base.util:beast.base.math:beast.evolution.nuc:beast.base.evolution.operator:beast.base.inference.operator:beast.base.evolution.sitemodel:beast.base.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.evolution:beast.base.inference.distribution'>
 
 
@@ -468,8 +468,8 @@ EBSPLogger/mode/
 
             <prior id="indicatorsPrior.alltrees" spec="beast.base.spec.inference.distribution.Prior">
                 <scalar arg="@indicators.alltrees" id="indsSun.alltrees" spec="beast.base.spec.evolution.Sum"/>
-                <distr spec="Poisson"  id='Poisson.EBSP'>
-                    <parameter name="lambda" value="0.69314718056" estimate='false'/>
+                <distr spec="beast.base.spec.inference.distribution.Poisson"  id='Poisson.EBSP'>
+                    <lambda spec="beast.base.spec.inference.parameter.RealScalarParam" domain="PositiveReal" value="0.69314718056" estimate="false"/>
                 </distr>
             </prior>
 

--- a/beast-fx/src/test/java/test/beastfx/app/beauti/CloneTest.java
+++ b/beast-fx/src/test/java/test/beastfx/app/beauti/CloneTest.java
@@ -127,6 +127,7 @@ public class CloneTest extends BeautiBase {
         makeSureXMLParses();       
 	}
 
+    // https://github.com/CompEvol/beast3/issues/136
 	@Disabled("Relaxed clock subtemplates not yet ported to BEAST 3 ClockModels.xml")
 	@Test
 	public void simpleClockModelCloneTest(FxRobot robot) throws Exception {


### PR DESCRIPTION
See #139 

Updates the BEAUti template XMLs (ClockModels.xml, ParametricDistributions.xml, Standard.xml, SubstModels.xml, TreePriors.xml) to point at the new `beast.base.spec.*` implementations instead of the legacy `beast.base.*` classes, especially `<map`, and bumps the `<beast version='...'>` attribute from 2.0 to 2.8 in all five files.

Key changes:
- Distributions: Dirichlet, Poisson, and the full set of univariate/multivariate/conditional distribution <map> entries in Standard.xml (Bernoulli, Beta, Cauchy, ChiSquare, Exponential, Gamma, LogNormal, Uniform, IID, OffsetInt/Real, TruncatedInt/Real, etc.) now reference beast.base.spec.inference.distribution.*. OneOnX was removed (noted in comment).
- Parameters: parameter.RealParameter usages replaced with the new spec parameter types (RealVectorParam, RealScalarParam), including domain='PositiveReal' attributes where applicable (e.g. popSize, Poisson.lambda).
- Substitution/tree/clock models: JukesCantor, RandomTree, ConstantPopulation and related inputLabelMap/inlinePlugins/stateWithoutInitialization entries updated to beast.base.spec.* equivalents; duplicate/legacy (non-spec) entries removed from Standard.xml's config lists.
- Standard.xml formatting: <map> block re-indented and reorganized with comments grouping univariate/multivariate/conditional distributions.

Additional:
- CloneTest.java: added a tracking comment (https://github.com/CompEvol/beast3/issues/136) above the @Disabled relaxed-clock subtemplate test, documenting why it's still skipped.