### PR TITLE
Make partition table cell edits deterministic (review of #144)

### DIFF
--- a/beast-fx/src/test/java/test/beastfx/app/beauti/BeautiBase.java
+++ b/beast-fx/src/test/java/test/beastfx/app/beauti/BeautiBase.java
@@ -631,6 +631,19 @@ System.err.println("Trying to load " + dir + " " + files[0]);
 	}
 
     protected void setPartitionTableCell(FxRobot robot, int col, String string) {
+    	setPartitionTableCell(robot, 0, col, string);
+	}
+
+	/**
+	 * Set the combo box of the partition table cell at the given row and column.
+	 * <p>
+	 * AlignmentListInputEditor's cell factory puts the same id and combo box graphic on
+	 * every TableCell it creates, including the recycled cells that back the empty rows
+	 * below the table, and those cells keep a live action handler. Firing an event on such
+	 * a cell would reach AlignmentListInputEditor.action() with a row index of -1, so pick
+	 * the cell by row rather than taking whatever node the lookup happens to return first.
+	 */
+    protected void setPartitionTableCell(FxRobot robot, int row, int col, String string) {
 		String cellId;
 		switch (col) {
 		case 5: cellId = "siteModelCell"; break;
@@ -638,7 +651,23 @@ System.err.println("Trying to load " + dir + " " + files[0]);
 		case 7: cellId = "treeModelCell"; break;
 		default: throw new IllegalArgumentException("Unsupported partition table column: " + col);
 		}
-		TableCell<?, ?> cell = (TableCell<?, ?>) robot.lookup("#" + cellId).query();
+		TableCell<?, ?> cell = null;
+		for (Node node : robot.lookup("#" + cellId).queryAll()) {
+			if (!(node instanceof TableCell)) {
+				continue;
+			}
+			TableCell<?, ?> candidate = (TableCell<?, ?>) node;
+			TableRow<?> tableRow = candidate.getTableRow();
+			if (candidate.isVisible() && !candidate.isEmpty()
+					&& tableRow != null && tableRow.getIndex() == row) {
+				cell = candidate;
+				break;
+			}
+		}
+		if (cell == null) {
+			throw new AssertionError("No visible #" + cellId + " found in row " + row
+					+ " of the partition table");
+		}
 		ComboBox<String> comboBox = (ComboBox<String>) cell.getGraphic();
 		robot.interact(() -> {
 			comboBox.getEditor().setText(string);

--- a/beast-fx/src/test/java/test/beastfx/app/beauti/BeautiSimpleTest.java
+++ b/beast-fx/src/test/java/test/beastfx/app/beauti/BeautiSimpleTest.java
@@ -96,10 +96,7 @@ public class BeautiSimpleTest extends BeautiBase {
 		
 		// rename tree from 'anolis' to 'tree'
 		robot.clickOn("#Partitions");
-		// table = robot.lookup(".table-view").queryAs(TableView.class);
-		robot.clickOn("#treeModelCell");
-		robot.eraseText(10);
-		robot.write("tree\n");
+		setPartitionTableCell(robot, 7, "tree");
 
 		printBeautiState();
 		assertStateEquals("Tree.t:tree", "birthRate.t:tree", "kappa.s:anolis", "gammaShape.s:anolis", "freqParameter.s:anolis");


### PR DESCRIPTION
Two changes from reviewing #144, targeted at `beautitests` so they land with that PR. One is a review comment on #144's code; the other is an opportunistic cleanup in a file #144 does not touch. Happy to drop the second if you'd rather keep the PR tight.

### 1. The new cell lookup can land on a recycled empty cell (review comment on this PR)

`robot.lookup("#" + cellId).query()` returns the first node with that id anywhere in the scene, unfiltered. `AlignmentListInputEditor`'s cell factory sets the id and the `ComboBox` graphic on *every* `TableCell` it creates — including the recycled cells backing the empty rows below the table (`updateItem` only does `setVisible(!empty)`) — and those keep a live `setOnAction(e -> action(e, COLUMN))` handler. If the lookup lands on one, the synthesized `ActionEvent` reaches `AlignmentListInputEditor.action()`, which does `tableEntries.get(row.getIndex())` with an index of `-1`, and the intended partition is never renamed. With no match at all, the cast failed with a bare NPE instead of a useful message.

The lookup now iterates the candidates and picks the visible, non-empty cell whose `TableRow` index matches the requested row, throwing a descriptive `AssertionError` if there is none. A `(robot, row, col, string)` overload was added; the existing three-arg form delegates to row 0, so no caller changes were needed.

### 2. `BeautiSimpleTest` adopting the new helper (cleanup, not a defect in this PR)

`BeautiSimpleTest.simpleTest` renames the tree with the same `clickOn(#treeModelCell)` + `eraseText(10)` + `write()` sequence that `setPartitionTableCell` was introduced to replace, then asserts `assertStateEquals("Tree.t:tree", …)`. It now calls `setPartitionTableCell(robot, 7, "tree")` instead.

To be clear about what this is: `BeautiSimpleTest` is byte-identical before and after #144, does not call `setPartitionTableCell`, and passes at the pre-#144 baseline — so it was not one of the tests failing in #143 and this is not an incomplete fix on your part. It is just consistency: one remaining copy of a pattern this PR establishes a better replacement for. If you'd prefer, I'll pull it out and raise it separately against master after #144 lands.

### Verification

- `mvn -pl beast-fx -am test-compile` passes.
- `BeautiSimpleTest` passes with these changes (`Tests run: 1, Failures: 0`), and also passes unchanged at `origin/beautitests`. Neither failure mode reproduces on a single isolated run on my machine, so treat both changes as hardening against timing/scene-graph-order dependence rather than as a demonstrated red→green fix.
- I have not run `BeautiDivergenceDatingTest` or `BeautiCLITest` against this branch.

### Note, not addressed here

All three `BeautiCLITest` bodies sit inside `if (!GraphicsEnvironment.isHeadless())`. Under a headless run the bodies — including the `f.exists() && f.length() > 0` assertions — never execute, so those tests pass vacuously and the rewritten template is not actually exercised. Pre-existing, but worth knowing when judging whether CI verifies this PR's fix.