### PR TITLE
Add nightly CI workflow for slow-tagged Beauti tests #147

### DIFF
--- a/.github/workflows/beauti-tests.yml
+++ b/.github/workflows/beauti-tests.yml
@@ -1,0 +1,54 @@
+name: Beauti Tests (beast-fx)
+
+# Runs the full BeastFX/Beauti TestFX suite, including the tests tagged
+# "slow" that ci-publish.yml skips on every push/PR (surefire.excludedGroups
+# defaults to "slow" — see root pom.xml). These are headless-JavaFX GUI
+# tests, slower and more flake-prone than the rest of the suite, so they
+# run nightly instead of gating every PR. Headless mode (TestFX + Monocle)
+# is already configured in beast-fx/pom.xml's surefire block, so no Xvfb
+# step is required.
+#
+# Triggers: nightly schedule, and workflow_dispatch for on-demand runs.
+
+on:
+  schedule:
+    # 01:00 NZST (Auckland, UTC+12) in winter, 02:00 NZDT (UTC+13) in summer.
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+
+jobs:
+  beauti-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 25 (Azul Zulu)
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: '25'
+          cache: maven
+
+      - name: Run beast-fx Beauti tests (including slow-tagged)
+        # -pl beast-fx -am also builds+runs the test phase for beast-fx's
+        #   reactor dependencies (beast-base, beast-pkgmgmt), so without
+        #   scoping we'd rerun their whole non-Beauti test suites too.
+        # -Dtest='test.beastfx.app.**' restricts execution to the Beauti/
+        #   TestFX package, which only exists in beast-fx.
+        # -Dsurefire.failIfNoSpecifiedTests=false stops surefire from
+        #   failing the build in beast-base/beast-pkgmgmt, where that
+        #   -Dtest pattern matches zero classes ("No tests were executed!"
+        #   is a hard error by default) — we want those modules to just
+        #   build and skip tests, not fail the job.
+        run: mvn -pl beast-fx -am test -Pslow-tests -Dtest='test.beastfx.app.**' -Dsurefire.failIfNoSpecifiedTests=false
+
+      - name: Upload surefire reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: beauti-test-reports
+          path: beast-fx/target/surefire-reports/
+          retention-days: 7

--- a/beast-base/src/test/java/test/beast/beast2vs1/tutorials/DivergenceDatingTest.java
+++ b/beast-base/src/test/java/test/beast/beast2vs1/tutorials/DivergenceDatingTest.java
@@ -1,16 +1,20 @@
 package test.beast.beast2vs1.tutorials;
 
 
+import beast.base.trace.Expectation;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import test.beast.beast2vs1.TestFramework;
-import beast.base.trace.Expectation;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @deprecated replaced by test.beastfx.app.beauti.BeautiDivergenceDatingTest
+ */
+@Deprecated
 public class DivergenceDatingTest {
     @Disabled("Missing x.xml tutorial file")
     @Test

--- a/beast-base/src/test/java/test/beast/beast2vs1/tutorials/RateTutorialTest.java
+++ b/beast-base/src/test/java/test/beast/beast2vs1/tutorials/RateTutorialTest.java
@@ -1,12 +1,16 @@
 package test.beast.beast2vs1.tutorials;
 
-import test.beast.beast2vs1.TestFramework;
 import beast.base.trace.Expectation;
+import test.beast.beast2vs1.TestFramework;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @deprecated replaced by test.beastfx.app.beauti.BeautiRateTutorialTest
+ */
+@Deprecated
 public class RateTutorialTest {
 
 //    @Test


### PR DESCRIPTION
Fix #147 

- Add `.github/workflows/beauti-tests.yml`: runs the beast-fx/Beauti TestFX suite, including tests tagged `slow` that `ci-publish.yml` skips on every push/PR (`surefire.excludedGroups=slow` in the root `pom.xml`). These are headless-JavaFX GUI tests — slower and more flake-prone — so they run nightly (`cron '0 13 * * *'`, 01:00 NZST/02:00 NZDT) plus on-demand via `workflow_dispatch`, rather than gating every PR.
- The test command is `mvn -pl beast-fx -am test -Pslow-tests -Dtest='test.beastfx.app.**' -Dsurefire.failIfNoSpecifiedTests=false`:
  - `-pl beast-fx -am` also pulls `beast-base`/`beast-pkgmgmt` into the reactor (beast-fx depends on both), so without scoping it would rerun their entire unrelated test suites too.
  - `-Dtest='test.beastfx.app.**'` restricts execution to the Beauti/TestFX package, which only exists in beast-fx.
  - `-Dsurefire.failIfNoSpecifiedTests=false` stops surefire from hard-failing the build in beast-base/beast-pkgmgmt, where that pattern matches zero classes ("No tests were executed!" is an error by default) — those modules should just build and skip tests, not fail the job.
- Mark `DivergenceDatingTest` and `RateTutorialTest` (beast-base) as `@Deprecated`, pointing to their beast-fx replacements `BeautiDivergenceDatingTest` / `BeautiRateTutorialTest`.

Tested in local :

Tests run: 45, Failures: 0, Errors: 0, Skipped: 6