### PR TITLE
Correct InverseGamma's mean and support bounds

### DIFF
--- a/beast-base/src/main/java/beast/base/spec/inference/distribution/InverseGamma.java
+++ b/beast-base/src/main/java/beast/base/spec/inference/distribution/InverseGamma.java
@@ -125,6 +125,19 @@ public class InverseGamma extends ScalarDistribution<RealScalar<PositiveReal>, D
         return 1.0 / dist.inverseSurvivalProbability(p);
     }
 
+    /**
+     * ScalarDistribution.getMean() delegates to getApacheDistribution().getMean(), i.e. the
+     * internal Gamma(alpha, rate=beta) helper's mean (alpha/beta), not InverseGamma's own mean
+     * of beta/(alpha-1). For alpha &le; 1 the defining integral diverges; since X &gt; 0 always,
+     * that divergence is to +Infinity (never negative or indeterminate), so +Infinity -- not NaN
+     * -- is returned there, consistent with beta/(alpha-1)'s own limit as alpha -&gt; 1+.
+     */
+    @Override
+    public double getMean() {
+        refresh(); // this make sure distribution parameters are updated if they are sampled during MCMC
+        return alpha > 1 ? beta / (alpha - 1) : Double.POSITIVE_INFINITY;
+    }
+
     @Override
 	public List<Double> sample() {
         if (sampler == null) {
@@ -136,9 +149,30 @@ public class InverseGamma extends ScalarDistribution<RealScalar<PositiveReal>, D
         return List.of(x);
     }
 
+    /**
+     * Support is (0, +Infinity), same as the internal Gamma helper's [0, +Infinity) -- but
+     * stated explicitly here (rather than relying on ScalarDistribution's default, which reads
+     * it off getApacheDistribution()) so it stays correct independent of what that returns.
+     */
+    @Override
+    public Double getLowerBoundOfParameter() {
+        return 0.0;
+    }
+
+    @Override
+    public Double getUpperBoundOfParameter() {
+        return Double.POSITIVE_INFINITY;
+    }
+
+    /**
+     * The internal Gamma helper only exists to draw samples via x = 1/y; it does not represent
+     * InverseGamma's own density/CDF/mean, all of which are overridden above without consulting
+     * it. Returning null (rather than the Gamma object) means any ScalarDistribution method added
+     * in future that is not also overridden here will fail loudly instead of silently returning a
+     * Gamma-distributed answer dressed up as an InverseGamma one.
+     */
     @Override
 	protected Object getApacheDistribution() {
-        refresh(); // this make sure distribution parameters are updated if they are sampled during MCMC
-        return dist;
+        return null;
     }
 } // class InverseGamma

--- a/beast-base/src/test/java/beast/base/spec/inference/distribution/InverseGammaTest.java
+++ b/beast-base/src/test/java/beast/base/spec/inference/distribution/InverseGammaTest.java
@@ -5,8 +5,7 @@ import beast.base.spec.inference.parameter.RealScalarParam;
 import org.apache.commons.statistics.distribution.GammaDistribution;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Simple test for inverse gamma distribution.
@@ -202,5 +201,118 @@ public class InverseGammaTest {
                 "beta", new RealScalarParam<>(2.0, PositiveReal.INSTANCE));
         assertEquals(0.0, d.inverseCumulativeProbability(0.0), 1e-10);
         assertEquals(Double.POSITIVE_INFINITY, d.inverseCumulativeProbability(1.0));
+    }
+
+    /**
+     * ScalarDistribution.getMean() also delegates to getApacheDistribution().getMean(), i.e. the
+     * internal Gamma(alpha, rate=beta) helper's mean (alpha/beta), not InverseGamma's own mean of
+     * beta/(alpha-1), which diverges to +Infinity (never negative or NaN, since X &gt; 0 always)
+     * as alpha -&gt; 1+ and stays there for alpha &le; 1.
+     */
+    @Test
+    public void testGetMeanMatchesInverseGammaNotGamma() {
+        for (TestData td : tests) {
+            double alpha = td.getShape();
+            double beta = td.getScale();
+
+            InverseGamma d = new InverseGamma();
+            d.initByName("alpha", new RealScalarParam<>(alpha, PositiveReal.INSTANCE),
+                    "beta", new RealScalarParam<>(beta, PositiveReal.INSTANCE));
+
+            GammaDistribution gamma = GammaDistribution.of(alpha, 1.0 / beta);
+
+            assertEquals(beta / (alpha - 1), d.getMean(), 1e-10);
+
+            // it must no longer be the raw Gamma mean (the pre-fix bug)
+            assertNotEquals(gamma.getMean(), d.getMean(), 1e-6);
+        }
+
+        // alpha = 2 is the boundary where the mean is still finite (beta/(alpha-1) = beta) but
+        // the variance (beta^2 / ((alpha-1)^2 (alpha-2))) is not.
+        InverseGamma alphaTwo = new InverseGamma();
+        alphaTwo.initByName("alpha", new RealScalarParam<>(2.0, PositiveReal.INSTANCE),
+                "beta", new RealScalarParam<>(1.0, PositiveReal.INSTANCE));
+        assertEquals(1.0, alphaTwo.getMean(), 1e-10);
+        assertNotEquals(GammaDistribution.of(2.0, 1.0).getMean(), alphaTwo.getMean(), 1e-6);
+
+        // mean diverges to +Infinity, continuously, as alpha approaches 1 from above ...
+        InverseGamma nearOne = new InverseGamma();
+        nearOne.initByName("alpha", new RealScalarParam<>(1.0 + 1e-6, PositiveReal.INSTANCE),
+                "beta", new RealScalarParam<>(2.0, PositiveReal.INSTANCE));
+        assertEquals(2.0 / 1e-6, nearOne.getMean(), 1.0);
+
+        // ... and is +Infinity, not NaN, at and below alpha = 1
+        for (double alpha : new double[]{1.0, 0.9, 0.5}) {
+            InverseGamma d = new InverseGamma();
+            d.initByName("alpha", new RealScalarParam<>(alpha, PositiveReal.INSTANCE),
+                    "beta", new RealScalarParam<>(2.0, PositiveReal.INSTANCE));
+            assertEquals(Double.POSITIVE_INFINITY, d.getMean());
+        }
+    }
+
+    /**
+     * getApacheDistribution() exposes the internal Gamma(alpha, rate=beta) helper, which is only
+     * used for sampling via x = 1/y and does not represent InverseGamma's own density/CDF/mean --
+     * all of which are overridden above without consulting it. It should therefore return null
+     * (per its own documented contract), so any ScalarDistribution method added later that isn't
+     * also overridden here fails loudly rather than silently returning a Gamma-distributed answer.
+     * getLowerBoundOfParameter()/getUpperBoundOfParameter() must therefore also be overridden
+     * directly (not derived from getApacheDistribution()) to keep returning the correct support,
+     * (0, +Infinity), and inverseCumulativeProbability's p<=0/p>=1 boundary handling (which calls
+     * them) must keep working.
+     */
+    @Test
+    public void testGetApacheDistributionIsNull() {
+        InverseGamma d = new InverseGamma();
+        d.initByName("alpha", new RealScalarParam<>(3.0, PositiveReal.INSTANCE),
+                "beta", new RealScalarParam<>(2.0, PositiveReal.INSTANCE));
+
+        assertNull(d.getApacheDistribution());
+
+        assertEquals(0.0, d.getLowerBoundOfParameter(), 1e-10);
+        assertEquals(Double.POSITIVE_INFINITY, d.getUpperBoundOfParameter());
+
+        // inverseCumulativeProbability's boundary handling still works without getApacheDistribution()
+        assertEquals(0.0, d.inverseCumulativeProbability(0.0), 1e-10);
+        assertEquals(Double.POSITIVE_INFINITY, d.inverseCumulativeProbability(1.0));
+    }
+
+    /**
+     * sample() draws y from the internal Gamma(alpha, rate=beta) helper and returns x = 1/y --
+     * this is the original "direct sampler" code path the whole InverseGamma investigation started
+     * from, but it had no test exercising it at all. Checks the empirical mean and empirical CDF
+     * of a large sample against getMean() and the reference CDF values (both independently
+     * verified correct elsewhere in this class), with tolerances set from the distribution's own
+     * (finite, for alpha=3) variance/binomial sampling error so the test isn't flaky.
+     */
+    @Test
+    public void testSampleDrawsFromInverseGamma() {
+        double alpha = 3;
+        double beta = 2;
+
+        InverseGamma d = new InverseGamma();
+        d.initByName("alpha", new RealScalarParam<>(alpha, PositiveReal.INSTANCE),
+                "beta", new RealScalarParam<>(beta, PositiveReal.INSTANCE));
+
+        final int n = 200_000;
+        double sum = 0;
+        int belowOne = 0;
+        for (int i = 0; i < n; i++) {
+            double x = d.sample().getFirst();
+            sum += x;
+            if (x < 1.0) {
+                belowOne++;
+            }
+        }
+        double sampleMean = sum / n;
+        double empiricalCdfAtOne = belowOne / (double) n;
+
+        // Var(X) = beta^2 / ((alpha-1)^2 (alpha-2)) = 1 for alpha=3, beta=2, so SE(mean) ~ 0.0022;
+        // 0.05 is a >20-sigma margin.
+        assertEquals(d.getMean(), sampleMean, 0.05);
+
+        // reference value from TestData for (alpha=3, beta=2) at x=1; SE(proportion) ~ 0.001,
+        // 0.02 is a similarly generous margin.
+        assertEquals(0.67667641618306, empiricalCdfAtOne, 0.02);
     }
 }


### PR DESCRIPTION
Summary:

Building on the earlier CDF/ICDF fix (#149), two more ScalarDistribution methods were found silently returning the internal Gamma helper's statistics instead of InverseGamma's own:

- getMean() was unoverridden, so it delegated to getApacheDistribution().getMean() — the internal Gamma(alpha, rate=beta) helper's mean (alpha/beta) — instead of InverseGamma's own mean (beta/(alpha-1)). Confirmed numerically: α=3, β=2 returned 1.5 instead of the correct 1.0.
- Fixed by overriding getMean() with beta/(alpha-1) for alpha > 1. For alpha ≤ 1 the defining integral diverges; since X > 0 always, that divergence is provably to +Infinity (never negative or indeterminate), so Double.POSITIVE_INFINITY is returned there rather than NaN — otherwise there'd be a discontinuity between alpha=1 (NaN) and values just above it (correctly huge, finite numbers approaching +Infinity).

Went further on getApacheDistribution() itself: it e if it were "the" Apache distribution backingInverseGamma, which is exactly what caused this bug (and the earlier CDF/ICDF one) — the Gamma object doesn't represent         InverseGamma's own density/CDF/mean at all, it's onlling via x = 1/y. Per the method's own documentedcontract ("or null otherwise"), it now returns null, so any future ScalarDistribution method that isn't explicitly overridden hewill throw instead of silently returning a Gamma-flae thing that implicitly relied on it —getLowerBoundOfParameter()/getUpperBoundOfParameter() — is now overridden directly with the hardcoded correct support, (0,      +Infinity), rather than derived from getApacheDistri
                                                                                                                                Test plan (InverseGammaTest, +3 tests):
- testGetMeanMatchesInverseGammaNotGamma: checks beta/(alpha-1) against the existing reference cases, plus alpha=2,beta=1 (mean still finite, but the boundary where variance stops of the mean as alpha → 1⁺, and +Infinity (not NaN)for alpha ∈ {1.0, 0.9, 0.5}.
- testGetApacheDistributionIsNull: checks the null rndOfParameter/getUpperBoundOfParameter overrides, and that inverseCumulativeProbability's p≤0/p≥1 boundary handling (which calls those) still works without getApacheDistribution().
- testSampleDrawsFromInverseGamma: sample() — the meoriginal bug report — had no test exercising it atall; this draws 200k samples and checks the empirical mean and empirical CDF against getMean()/reference values, with tolerances
sized from the distribution's own finite variance soross repeated runs).

mvn test -Dtest=InverseGammaTest → 6/6 pass. Full beass, 0 regressions.