### PR TITLE
fix a BEAUti bug to drop package-provided InputEditors and add tests 

### DIFF
--- a/beast-fx/src/main/java/beastfx/app/inputeditor/InputEditorFactory.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/InputEditorFactory.java
@@ -1,31 +1,24 @@
 package beastfx.app.inputeditor;
 
 
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.ServiceLoader;
-import java.util.Set;
-
 import beast.base.core.BEASTInterface;
 import beast.base.core.Input;
-import beast.base.core.Log;
 import beast.base.core.Input.Validate;
+import beast.base.core.Log;
 import beast.pkgmgmt.BEASTClassLoader;
 import beast.pkgmgmt.PackageManager;
 import beastfx.app.inputeditor.InputEditor.ButtonStatus;
 import beastfx.app.inputeditor.InputEditor.ExpandOption;
 import beastfx.app.util.Alert;
-import javafx.scene.Node;
 import javafx.scene.layout.VBox;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
 
 
-/** Can create InputEditors for inputs of BEASTObjects 
+/** Can create InputEditors for inputs of BEASTObjects
  * and there are some associated utility methods **/
 public class InputEditorFactory {
     /**
@@ -54,10 +47,19 @@ public class InputEditorFactory {
             registerInputEditors(new String[]{editor.getClass().getName()});
         }
 
-        if (beast.pkgmgmt.Utils6.isJUnitTest() || inputEditorMap.size() == 0) {
-        	Set<String> inputEditors = PackageManager.listServices("beastfx.app.inputeditor.InputEditor");
-            registerInputEditors(inputEditors.toArray(new String[0]));
-        }
+        // ServiceLoader.load() only resolves providers visible from this class's own
+        // module layer/classpath, so it never sees editors contributed by BEAST
+        // *packages* (e.g. starbeast3), which BEASTClassLoader loads into a separate
+        // plugin ModuleLayer at runtime. This is expected JPMS behaviour, not a
+        // ServiceLoader defect -- a plugin layer is intentionally isolated from the
+        // caller's own layer/classpath. PackageManager.listServices() is what actually
+        // finds those (via each package's version.xml), so it must always run -- not
+        // just when the ServiceLoader pass came back empty -- otherwise every
+        // package-provided editor is silently dropped whenever the core beast.fx
+        // editors were already found above. Never treat a non-empty ServiceLoader
+        // result as proof that nothing else is left to find.
+        Set<String> inputEditors = PackageManager.listServices("beastfx.app.inputeditor.InputEditor");
+        registerInputEditors(inputEditors.toArray(new String[0]));
     }
 
     

--- a/beast-fx/src/test/java/test/beastfx/app/beauti/InputEditorFactoryPackageDiscoveryTest.java
+++ b/beast-fx/src/test/java/test/beastfx/app/beauti/InputEditorFactoryPackageDiscoveryTest.java
@@ -1,0 +1,186 @@
+package test.beastfx.app.beauti;
+
+import beastfx.app.inputeditor.BEASTObjectInputEditor;
+import beastfx.app.inputeditor.BeautiDoc;
+import beastfx.app.inputeditor.InputEditorFactory;
+import javafx.application.Platform;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import test.beastfx.app.beauti.fixtures.PackageProvidedInputEditor;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for a bug in {@link InputEditorFactory#init()}: it could silently drop every
+ * BEAUti InputEditor that a BEAST <i>package</i> provides (for example starbeast3's
+ * {@code MRCAPriorInputEditorSB3}), so BEAUti would fall back to a generic built-in editor instead
+ * of the package's own one.
+ *
+ * <h2>What went wrong</h2>
+ * {@code init()} looks for InputEditors in two passes. The buggy version looked like this:
+ *
+ * <pre>{@code
+ * Iterable<InputEditor> editors = ServiceLoader.load(InputEditor.class);
+ * for (InputEditor editor : editors) {
+ *     registerInputEditors(new String[]{editor.getClass().getName()});
+ * }
+ * if (isJUnitTest() || inputEditorMap.size() == 0) {          // <-- the bug
+ *     Set<String> inputEditors = PackageManager.listServices("beastfx.app.inputeditor.InputEditor");
+ *     registerInputEditors(inputEditors.toArray(new String[0]));
+ * }
+ * }</pre>
+ *
+ * <ol>
+ *   <li><b>Pass 1</b> uses plain {@code ServiceLoader.load()}. This only finds InputEditors that
+ *       live in beast.fx's own module -- the built-in "core" editors.</li>
+ *   <li><b>Pass 2</b> uses {@code PackageManager.listServices()}, which reads every installed
+ *       BEAST package's {@code version.xml}. This is the <i>only</i> way an external package's
+ *       InputEditor is ever found, because a package is loaded into its own separate JPMS
+ *       {@code ModuleLayer} at runtime, and plain {@code ServiceLoader.load()} cannot see into
+ *       that layer.</li>
+ * </ol>
+ * The bug is the {@code if}: pass 2 only ran when pass 1 had found <i>nothing at all</i>
+ * ({@code inputEditorMap.size() == 0}). In a real BEAUti run, pass 1 always finds several core
+ * editors, so the map is never empty, so pass 2 never runs, so no package's InputEditors are ever
+ * registered -- silently. The fix simply always runs pass 2, in addition to pass 1.
+ *
+ * <h2>How this test reproduces it</h2>
+ * Rather than installing a real BEAST package (which needs a whole separate ModuleLayer), this
+ * test reproduces the same two discovery mechanisms with one real beast.fx class and one small
+ * test-only fixture:
+ * <ul>
+ *   <li>{@link BEASTObjectInputEditor} is a real, ordinary beast.fx core editor -- it is one of the
+ *       classes genuinely listed in beast-fx's own {@code module-info.java} {@code provides}
+ *       clause. It plays the role of "a core beast.fx editor" in this test. To make pass 1 find it
+ *       even when the test runs on the plain classpath (see the note below), it is <i>also</i>
+ *       listed in a test-only {@code META-INF/services/beastfx.app.inputeditor.InputEditor}
+ *       resource -- the classic {@code ServiceLoader} registration file. Its only purpose here is
+ *       to make pass 1 find <i>something</i>, so {@code inputEditorMap} is non-empty by the time
+ *       pass 2 is considered.</li>
+ *   <li>{@link PackageProvidedInputEditor} stands in for <b>an external package's editor</b> (the
+ *       role {@code MRCAPriorInputEditorSB3} plays for starbeast3). It is listed only in a test
+ *       {@code version.xml} {@code <service>} entry, so it is reachable <i>only</i> through pass
+ *       2 ({@code PackageManager.listServices()}) and is invisible to {@code ServiceLoader.load()}.
+ *       Whether this one gets registered is the actual thing this test checks.</li>
+ * </ul>
+ * <b>Maven CLI vs. an IDE (e.g. IntelliJ):</b> a {@code META-INF/services} file is only honoured by
+ * {@code ServiceLoader} for classes on the plain classpath (the "unnamed module"). Maven Surefire
+ * runs beast-fx's tests that way, so there it is the test's own {@code META-INF/services} entry
+ * that makes pass 1 find {@link BEASTObjectInputEditor} -- beast-fx ships no such file of its own,
+ * so without this fixture entry pass 1 would find nothing there. An IDE that runs tests as part of
+ * the real {@code beast.fx} JPMS module (IntelliJ does, by default, because beast-fx has a
+ * {@code module-info.java}) ignores that same test-only file -- a {@code META-INF/services} entry
+ * inside a named module is not read by {@code ServiceLoader}, only a real {@code provides} clause
+ * in {@code module-info.java} is. There, the test's {@code META-INF/services} entry is simply never
+ * read, but {@link BEASTObjectInputEditor} is still found regardless, via its <i>genuine</i>
+ * {@code provides} declaration -- the same one a real BEAUti run relies on. Either way, by the time
+ * pass 2 runs, something from pass 1 is already in the map -- which is the only thing that actually
+ * matters for reproducing the bug. That is why the first assertion below checks
+ * "{@code inputEditorMap} is not empty" rather than checking for {@link BEASTObjectInputEditor}
+ * specifically.
+ *
+ * <p><b>This split is not a {@code ServiceLoader} bug.</b> It is deliberate JPMS behaviour: a named
+ * module's {@code module-info.java} is meant to be the single, compiler-checked source of what it
+ * provides (two of the module system's core design goals, "reliable configuration" and "strong
+ * encapsulation" -- see JEP 261), so once a class lives in a named module, {@code ServiceLoader}
+ * intentionally stops honouring a {@code META-INF/services} file bundled inside that same module;
+ * only {@code provides} counts there. {@code META-INF/services} remains fully supported for
+ * providers on the plain class path (the unnamed module) -- beast-fx just doesn't ship one of its
+ * own for {@code InputEditor} (it relies on {@code provides} instead), which is precisely why pass 1
+ * finds beast-fx's real core editors when the test runs as part of the named {@code beast.fx}
+ * module (an IDE) but finds none of them under a plain class-path run (Maven Surefire) -- hence why
+ * this test needs its own {@code META-INF/services} entry to reproduce that "pass 1 found
+ * something" precondition there. The real bug -- the one this test exists to catch -- is entirely
+ * on the beast-fx side: {@code InputEditorFactory.init()} assumed a non-empty result from pass 1
+ * meant "nothing more to look for", which is simply the wrong inference to draw from a mechanism
+ * whose completeness depends on which mode the JVM happens to be running in.
+ *
+ * <h2>Why the registration call runs on the FX thread</h2>
+ * The call to {@code new InputEditorFactory(doc)} below happens inside {@link Platform#runLater},
+ * not directly in the {@code @Test} method. This is deliberate: {@code Utils6.isJUnitTest()}
+ * checks the calling thread's stack trace for {@code org.junit.*} frames, and the pre-fix guard
+ * had {@code || isJUnitTest()} specifically so that tests always ran pass 2, no matter what pass 1
+ * found. Calling {@code new InputEditorFactory(doc)} straight from the {@code @Test} method would
+ * trip that escape hatch and make this test pass even against the buggy code. Running it from the
+ * FX Application Thread avoids that -- and matches real BEAUti, which always constructs
+ * {@code InputEditorFactory} from that same thread.
+ */
+@ExtendWith(ApplicationExtension.class)
+public class InputEditorFactoryPackageDiscoveryTest {
+
+    @Start
+    public void start(Stage stage) {
+        // no UI needed; @Start just gets the JavaFX toolkit initialised
+    }
+
+    @Test
+    public void packageProvidedEditorIsRegistered() throws Exception {
+        AtomicReference<Map<Class<?>, String>> result = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Run on the FX Application Thread, not the JUnit thread -- see "Why the registration call
+        // runs on the FX thread" above. Calling this from the @Test method directly would make the
+        // test pass even against the buggy code.
+        Platform.runLater(() -> {
+            try {
+                BeautiDoc doc = new BeautiDoc();
+                // The real, unmodified InputEditorFactory.init() runs here (called from the
+                // constructor) and registers both BEASTObjectInputEditor and the
+                // PackageProvidedInputEditor fixture from the test classpath.
+                InputEditorFactory factory = new InputEditorFactory(doc);
+
+                Field f = InputEditorFactory.class.getDeclaredField("inputEditorMap");
+                f.setAccessible(true);
+                @SuppressWarnings("unchecked")
+                Map<Class<?>, String> map = (Map<Class<?>, String>) f.get(factory);
+                result.set(map);
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "InputEditorFactory init timed out on the FX thread");
+        if (error.get() != null) {
+            throw new AssertionError(error.get());
+        }
+        Map<Class<?>, String> inputEditorMap = result.get();
+
+        // Step 1 -- sanity check, not the actual regression test: confirm pass 1 (ServiceLoader)
+        // found *something*, so inputEditorMap is non-empty going into pass 2. We deliberately do
+        // NOT check for BEASTObjectInputEditor specifically here -- see "Maven CLI vs. an IDE"
+        // above: under a plain classpath run (e.g. Maven Surefire) it's found via the test's own
+        // META-INF/services entry; under a real JPMS module-path run (e.g. IntelliJ's default test
+        // runner) it's found via its own genuine module-info "provides" clause instead -- either
+        // way it's the same class, just discovered through a different mechanism. Checking for
+        // "non-empty" rather than this specific class keeps the assertion valid in both cases. If
+        // this assertion ever fails, the test setup is broken and step 2 below wouldn't be testing
+        // anything meaningful.
+        assertFalse(inputEditorMap.isEmpty(),
+                "test setup problem: inputEditorMap was empty after pass 1 (ServiceLoader), so "
+                + "this test isn't exercising the size()==0 guard the bug lived in -- fix the test "
+                + "fixtures before trusting the assertion below");
+
+        // Step 2 -- the actual regression check: was our "package editor" stand-in registered too?
+        // It is only reachable via PackageManager.listServices() (pass 2). On the pre-fix code,
+        // pass 2 never ran here because step 1 already proved pass 1 found something -- so this
+        // assertion fails against the bug and passes once it's fixed.
+        assertEquals(PackageProvidedInputEditor.class.getName(),
+                inputEditorMap.get(PackageProvidedInputEditor.Target.class),
+                "PackageProvidedInputEditor (registered only via version.xml) was not found -- "
+                + "this is the bug: InputEditorFactory.init() only calls "
+                + "PackageManager.listServices() when ServiceLoader found nothing, so it drops "
+                + "every package-provided editor as soon as a core editor is found first");
+    }
+}

--- a/beast-fx/src/test/java/test/beastfx/app/beauti/fixtures/PackageProvidedInputEditor.java
+++ b/beast-fx/src/test/java/test/beastfx/app/beauti/fixtures/PackageProvidedInputEditor.java
@@ -1,0 +1,49 @@
+package test.beastfx.app.beauti.fixtures;
+
+import beast.base.core.BEASTInterface;
+import beast.base.core.Input;
+import beastfx.app.inputeditor.BeautiDoc;
+import beastfx.app.inputeditor.InputEditor;
+
+/**
+ * Test fixture standing in for an InputEditor contributed by an external BEAST <b>package</b> --
+ * the same role starbeast3's {@code MRCAPriorInputEditorSB3} plays for real.
+ *
+ * <p>It is listed only in the test resource {@code src/test/resources/version.xml}, under a
+ * {@code <service type="beastfx.app.inputeditor.InputEditor">} entry -- the same way a real BEAST
+ * package declares its editors. It deliberately has <b>no</b> {@code META-INF/services} entry, so
+ * plain {@code ServiceLoader.load(InputEditor.class)} can never find it; the only way to discover
+ * it is via {@code PackageManager.listServices()}, which reads {@code version.xml}.
+ *
+ * <p>On a real deployment, a package like starbeast3 is loaded into its own JPMS plugin
+ * {@code ModuleLayer} at runtime, which is exactly why plain {@code ServiceLoader} can never see
+ * into it. This fixture reproduces that same "invisible to ServiceLoader, visible only via
+ * {@code PackageManager.listServices()}" situation without needing a real package or ModuleLayer.
+ *
+ * <p>See {@link test.beastfx.app.beauti.InputEditorFactoryPackageDiscoveryTest} for how this is
+ * used -- whether this class gets registered is the actual thing that test checks.
+ */
+public class PackageProvidedInputEditor extends InputEditor.Base {
+
+    /** stand-in for a BEASTObject type this fixture editor "handles" */
+    public static class Target {}
+
+    public PackageProvidedInputEditor() {
+        super();
+    }
+
+    public PackageProvidedInputEditor(BeautiDoc doc) {
+        super(doc);
+    }
+
+    @Override
+    public Class<?> type() {
+        return Target.class;
+    }
+
+    @Override
+    public void init(Input<?> input, BEASTInterface beastObject, int itemNr,
+                      ExpandOption isExpandOption, boolean addButtons) {
+        // not exercised by this test
+    }
+}

--- a/beast-fx/src/test/resources/META-INF/services/beastfx.app.inputeditor.InputEditor
+++ b/beast-fx/src/test/resources/META-INF/services/beastfx.app.inputeditor.InputEditor
@@ -1,0 +1,6 @@
+# Test-only fixture for InputEditorFactoryPackageDiscoveryTest (see that class for the full
+# explanation). This is a standard java.util.ServiceLoader registration file: it makes
+# ServiceLoader.load(InputEditor.class) able to find beast.fx's real BEASTObjectInputEditor on
+# the plain classpath, the same way ServiceLoader finds it via module-info's "provides" clause
+# in a real modular BEAUti run.
+beastfx.app.inputeditor.BEASTObjectInputEditor

--- a/beast-fx/src/test/resources/version.xml
+++ b/beast-fx/src/test/resources/version.xml
@@ -1,0 +1,11 @@
+<!--
+  Test-only fixture for InputEditorFactoryPackageDiscoveryTest (see that class for the full
+  explanation). This file makes PackageManager.listServices() able to find
+  PackageProvidedInputEditor, the same way it would find a real external package's editors by
+  reading that package's version.xml.
+-->
+<package name='TestFixturePackage' version='1.0.0'>
+    <service type="beastfx.app.inputeditor.InputEditor">
+        <provider classname="test.beastfx.app.beauti.fixtures.PackageProvidedInputEditor"/>
+    </service>
+</package>


### PR DESCRIPTION
Fix #153

## Problem

`InputEditorFactory.init()` only consulted `PackageManager.listServices()` (the
mechanism that discovers InputEditors contributed by external BEAST packages, via
their `version.xml`) when `ServiceLoader.load()` had found **zero** editors. Since a
real BEAUti run always finds several core beast.fx editors via `ServiceLoader` first,
that condition was never true in practice — meaning package-provided editors (e.g.
starbeast3's `MRCAPriorInputEditorSB3`) were never registered, silently. See #<issue-number>.

`ServiceLoader.load()` cannot see into the separate JPMS `ModuleLayer` that
`PackageManager` loads each package into at runtime — that's expected JPMS design, not
a defect — so `PackageManager.listServices()` is not optional supplementary discovery;
it's the *only* path to package-provided editors and must always run.

## Fix

`beast-fx/src/main/java/beastfx/app/inputeditor/InputEditorFactory.java`:
removed the `inputEditorMap.size() == 0` (and the now-redundant `isJUnitTest()`) guard
around the `PackageManager.listServices()` call, so it always runs in addition to the
`ServiceLoader.load()` pass, merging results from both. `registerInputEditors()`
already just adds map entries, so this cannot clobber any core editor already found by
`ServiceLoader` — it can only add entries for types core editors don't already cover.

```diff
- if (beast.pkgmgmt.Utils6.isJUnitTest() || inputEditorMap.size() == 0) {
-     Set<String> inputEditors = PackageManager.listServices("beastfx.app.inputeditor.InputEditor");
-     registerInputEditors(inputEditors.toArray(new String[0]));
- }
+ Set<String> inputEditors = PackageManager.listServices("beastfx.app.inputeditor.InputEditor");
+ registerInputEditors(inputEditors.toArray(new String[0]));

Testing

Added InputEditorFactoryPackageDiscoveryTest (beast-fx/src/test/java/test/beastfx/app/beauti/),
a regression test that reproduces the bug without needing a real external package or a
second ModuleLayer:

- beastfx.app.inputeditor.BEASTObjectInputEditor (a real beast.fx core editor) stands
  in for "a core editor ServiceLoader finds first." A test-only
  META-INF/services/beastfx.app.inputeditor.InputEditor resource makes it
  discoverable under a plain classpath test run (e.g. Maven Surefire); under a true
  JPMS module-path run (e.g. IntelliJ's default test runner) it's found via its own
  genuine provides declaration instead — either way, inputEditorMap is non-empty
  going into pass 2, matching real BEAUti.
- test.beastfx.app.beauti.fixtures.PackageProvidedInputEditor stands in for an
  external package's editor: registered only via a test version.xml <service>
  entry, invisible to ServiceLoader.load(). Whether this one gets registered is the
  actual regression check.
- The registration call runs via Platform.runLater rather than directly on the JUnit
  thread, since the pre-fix guard's || isJUnitTest() clause would otherwise mask the
  bug under test.

Verified both directions by toggling the fix:
- Unpatched InputEditorFactory: test fails (PackageProvidedInputEditor not found).
- Patched: test passes.
- Full beast-fx suite: 37/37 passing.
- Confirmed against real starbeast3 too: built it as an installable package, loaded it
  into its own plugin ModuleLayer via PackageManager (the real production path),
  and confirmed MRCAPriorSB3.class now resolves to
  starbeast3.app.beauti.MRCAPriorInputEditorSB3 in InputEditorFactory's registry
  (previously resolved to null / fell back to the generic superclass editor).

Files changed

- beast-fx/src/main/java/beastfx/app/inputeditor/InputEditorFactory.java — the fix
- beast-fx/src/test/java/test/beastfx/app/beauti/InputEditorFactoryPackageDiscoveryTest.java — regression test
- beast-fx/src/test/java/test/beastfx/app/beauti/fixtures/PackageProvidedInputEditor.java — test fixture
- beast-fx/src/test/resources/META-INF/services/beastfx.app.inputeditor.InputEditor — test fixture registration
- beast-fx/src/test/resources/version.xml — test fixture registration