### PR TITLE
Fix hyper-prior support for spec-framework distribution parameters

### DIFF
--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiConfig.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiConfig.java
@@ -1,25 +1,20 @@
 package beastfx.app.inputeditor;
 
 
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import beastfx.app.util.Alert;
-import beastfx.app.util.FXUtils;
-import javafx.scene.Parent;
 import beast.base.core.BEASTInterface;
 import beast.base.core.BEASTObject;
 import beast.base.core.Description;
 import beast.base.core.Input;
 import beast.base.core.Input.Validate;
 import beast.base.evolution.alignment.Alignment;
-import beast.base.spec.evolution.tree.MRCAPrior;
 import beast.base.parser.XMLParser;
+import beast.base.spec.evolution.tree.MRCAPrior;
+import beastfx.app.util.Alert;
+import beastfx.app.util.FXUtils;
+import javafx.scene.Parent;
+
+import java.io.File;
+import java.util.*;
 
 @Description("Beauti configuration object, used to find Beauti configuration " +
         "information from Beauti template files.")
@@ -92,7 +87,16 @@ public class BeautiConfig extends BEASTObject {
     public List<BeautiAlignmentProvider> alignmentProvider;
 
     public BeautiSubTemplate hyperPriorTemplate = null;
-    
+    /** hyper prior template for spec-framework (RealScalarParam-based) distribution parameters
+     * whose domain is unbounded Real, e.g. LogNormal's M -- kept separate from hyperPriorTemplate,
+     * which is still used by the legacy ParameterInputEditor for RealParameter-based priors
+     * (e.g. when loading an old analysis) */
+    public BeautiSubTemplate hyperPriorSpecTemplate = null;
+    /** as hyperPriorSpecTemplate, but for PositiveReal/NonNegativeReal-domain parameters, e.g.
+     * LogNormal's S -- a Normal prior would be domain-incompatible with such a parameter (it
+     * would show as an invalid/mismatched entry in the distribution dropdown) */
+    public BeautiSubTemplate hyperPriorSpecPositiveTemplate = null;
+
     @Override
     public void initAndValidate() {
         parseSet(inlineInput.get(), null, inlineBEASTObject);
@@ -123,8 +127,12 @@ public class BeautiConfig extends BEASTObject {
         alignmentProvider = alignmentProviderInput.get();
 
         try {
-            XMLParser parser = new XMLParser();
-        	hyperPriorTemplate = (BeautiSubTemplate) parser.parseBareFragment(HYPER_PRIOR_XML, true);
+        	// a fresh XMLParser per fragment -- the parser keeps mutable DOM state
+        	// internally, and reusing one instance across multiple parseBareFragment()
+        	// calls corrupts the second parse (stray "]]>" CDATA-boundary errors)
+        	hyperPriorTemplate = (BeautiSubTemplate) new XMLParser().parseBareFragment(HYPER_PRIOR_XML, true);
+        	hyperPriorSpecTemplate = (BeautiSubTemplate) new XMLParser().parseBareFragment(HYPER_PRIOR_SPEC_XML, true);
+        	hyperPriorSpecPositiveTemplate = (BeautiSubTemplate) new XMLParser().parseBareFragment(HYPER_PRIOR_SPEC_POSITIVE_XML, true);
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -153,7 +161,70 @@ public class BeautiConfig extends BEASTObject {
     		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='HyperPrior.$(n)'           targetID='prior' inputName='distribution' if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'>Hyper prior for parameter $(n)</connect>\n" +
     		"    	        </subtemplate>\n" +
     		"    	</beast>\n";
-    
+
+    /**
+     * Hyper prior for a spec-framework distribution's own parameter whose domain is unbounded
+     * Real (e.g. LogNormal's M). Unlike the legacy template above, the distribution is connected
+     * to 'prior' directly (there is no wrapping Prior object any more). A Normal + random walk is
+     * used since the target's domain is not restricted to positive values, unlike the legacy
+     * OneOnX (which has no spec equivalent) + multiplicative ScaleOperator.
+     */
+    final static String HYPER_PRIOR_SPEC_XML =
+    		"    <beast version='2.8'\n" +
+    		"    	       namespace='beastfx.app.beauti:beast.base.core'>\n" +
+    		"    	<!-- Parameter Hyper Prior for spec-framework distribution parameters -->\n" +
+    		"    	        <subtemplate spec='beastfx.app.inputeditor.BeautiSubTemplate' id='HyperPriorSpec' class='beast.base.spec.inference.distribution.Normal' mainid='HyperPriorSpec.$(n)'>\n" +
+    		"    	<![CDATA[\n" +
+    		"    	        <distribution id='HyperPriorSpec.$(n)' spec='beast.base.spec.inference.distribution.Normal' param='@parameter.$(n)'>\n" +
+    		"    	            <sigma spec='beast.base.spec.inference.parameter.RealScalarParam' domain='PositiveReal' value='10.0' estimate='false'/>\n" +
+    		"    	        </distribution>\n" +
+    		"\n" +
+    		"    	        <operator id='hyperRandomWalk.$(n)' spec='beast.base.spec.inference.operator.RealRandomWalkOperator' scalar='@parameter.$(n)' windowSize='1' weight='0.1'/>\n" +
+    		"    	]]>\n" +
+    		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='parameter.$(n)'            targetID='state' inputName='stateNode' if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'/>\n" +
+    		"\n" +
+    		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='hyperRandomWalk.$(n)'      targetID='mcmc' inputName='operator' if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'>Random walk on hyper parameter $(n)</connect>\n" +
+    		"\n" +
+    		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='parameter.$(n)'            targetID='tracelog' inputName='log'  if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'/>\n" +
+    		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='HyperPriorSpec.$(n)'       targetID='tracelog' inputName='log'  if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'/>\n" +
+    		"\n" +
+    		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='HyperPriorSpec.$(n)'       targetID='prior' inputName='distribution' if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'>Hyper prior for parameter $(n)</connect>\n" +
+    		"    	        </subtemplate>\n" +
+    		"    	</beast>\n";
+
+    /**
+     * As HYPER_PRIOR_SPEC_XML, but for a PositiveReal/NonNegativeReal-domain parameter (e.g.
+     * LogNormal's S, Gamma's alpha/theta). A Normal prior is domain-incompatible with such a
+     * parameter (it would show as a mismatched entry outside the compatible-domain dropdown list
+     * in the Priors panel -- see ScalarDistributionInputEditor.isCompatible), so a Gamma is used
+     * instead, matching the weak/vague-prior convention already used elsewhere in Standard.xml
+     * (e.g. MutationRatePrior, ClockPrior, YuleBirthRatePrior), together with the same
+     * multiplicative ScaleOperator used for other PositiveReal-domain parameters.
+     */
+    final static String HYPER_PRIOR_SPEC_POSITIVE_XML =
+    		"    <beast version='2.8'\n" +
+    		"    	       namespace='beastfx.app.beauti:beast.base.core'>\n" +
+    		"    	<!-- Parameter Hyper Prior for spec-framework PositiveReal/NonNegativeReal-domain distribution parameters -->\n" +
+    		"    	        <subtemplate spec='beastfx.app.inputeditor.BeautiSubTemplate' id='HyperPriorSpecPositive' class='beast.base.spec.inference.distribution.Gamma' mainid='HyperPriorSpecPositive.$(n)'>\n" +
+    		"    	<![CDATA[\n" +
+    		"    	        <distribution id='HyperPriorSpecPositive.$(n)' spec='beast.base.spec.inference.distribution.Gamma' param='@parameter.$(n)'>\n" +
+    		"    	            <alpha spec='beast.base.spec.inference.parameter.RealScalarParam' domain='PositiveReal' value='0.001' estimate='false'/>\n" +
+    		"    	            <theta spec='beast.base.spec.inference.parameter.RealScalarParam' domain='PositiveReal' value='1000.0' estimate='false'/>\n" +
+    		"    	        </distribution>\n" +
+    		"\n" +
+    		"    	        <operator id='hyperScaler.$(n)' spec='beast.base.spec.inference.operator.ScaleOperator' scaleFactor='0.5' weight='0.1' parameter='@parameter.$(n)'/>\n" +
+    		"    	]]>\n" +
+    		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='parameter.$(n)'              targetID='state' inputName='stateNode' if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'/>\n" +
+    		"\n" +
+    		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='hyperScaler.$(n)'            targetID='mcmc' inputName='operator' if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'>Scale hyper parameter $(n)</connect>\n" +
+    		"\n" +
+    		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='parameter.$(n)'              targetID='tracelog' inputName='log'  if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'/>\n" +
+    		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='HyperPriorSpecPositive.$(n)' targetID='tracelog' inputName='log'  if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'/>\n" +
+    		"\n" +
+    		"    	            <connect spec='beastfx.app.inputeditor.BeautiConnector' srcID='HyperPriorSpecPositive.$(n)' targetID='prior' inputName='distribution' if='inposterior(parameter.$(n)) and parameter.$(n)/estimate=true'>Hyper prior for parameter $(n)</connect>\n" +
+    		"    	        </subtemplate>\n" +
+    		"    	</beast>\n";
+
     public void setDoc(BeautiDoc doc) {
         partitionTemplate.get().setDoc(doc);
         for (BeautiSubTemplate sub : subTemplates) {
@@ -161,6 +232,8 @@ public class BeautiConfig extends BEASTObject {
         }
         doc.setExpertMode(isExpertInput.get());
         hyperPriorTemplate.doc = doc;
+        hyperPriorSpecTemplate.doc = doc;
+        hyperPriorSpecPositiveTemplate.doc = doc;
     }
 
     public void clear() {

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/BeautiDoc.java
@@ -1632,6 +1632,8 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
 
             List<BeautiSubTemplate> templates = new ArrayList<>();
             templates.add(beautiConfig.hyperPriorTemplate);
+            templates.add(beautiConfig.hyperPriorSpecTemplate);
+            templates.add(beautiConfig.hyperPriorSpecPositiveTemplate);
             for (BEASTInterface beastObject : pluginmap.values()) {
                 if (beastObject instanceof StateNode) {
                     if (beastObject.getID() != null && beastObject.getID().startsWith("parameter.")) {

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/spec/ScalarInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/spec/ScalarInputEditor.java
@@ -1,24 +1,21 @@
 package beastfx.app.inputeditor.spec;
 
 
-
 import beast.base.core.BEASTInterface;
 import beast.base.core.Input;
 import beast.base.core.Log;
 import beast.base.evolution.branchratemodel.BranchRateModel;
-import beast.base.inference.Distribution;
 import beast.base.inference.Operator;
 import beast.base.inference.StateNode;
 import beast.base.parser.PartitionContext;
+import beast.base.spec.domain.NonNegativeReal;
+import beast.base.spec.domain.PositiveReal;
 import beast.base.spec.inference.distribution.ScalarDistribution;
 import beast.base.spec.inference.parameter.BoolScalarParam;
 import beast.base.spec.inference.parameter.IntScalarParam;
 import beast.base.spec.inference.parameter.RealScalarParam;
 import beast.base.spec.type.Scalar;
-import beastfx.app.inputeditor.BEASTObjectDialog;
-import beastfx.app.inputeditor.BEASTObjectInputEditor;
-import beastfx.app.inputeditor.BEASTObjectPanel;
-import beastfx.app.inputeditor.BeautiDoc;
+import beastfx.app.inputeditor.*;
 import beastfx.app.util.Alert;
 import beastfx.app.util.FXUtils;
 import javafx.geometry.Insets;
@@ -30,9 +27,6 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 
 import java.util.List;
-
-
-
 
 
 public class ScalarInputEditor extends BEASTObjectInputEditor {
@@ -212,7 +206,9 @@ public class ScalarInputEditor extends BEASTObjectInputEditor {
             //m_bAddButtons = false;
             if (itemNr < 0) {
 	            for (Object beastObject2 : ((BEASTInterface) m_input.get()).getOutputs()) {
-	                if (beastObject2 instanceof RealScalarParam) {
+	                // a distribution whose *own* parameter (mean, sigma, alpha, ...) this is,
+	                // as opposed to a distribution for which this is the target (paramInput)
+	                if (beastObject2 instanceof ScalarDistribution<?,?> sd && sd.paramInput.get() != parameter) {
 	                    m_isEstimatedBox.setVisible(doc.allowLinking);
 	                    m_isEstimatedBox.setVisible(true);
 	                	isParametricDistributionParameter = true;
@@ -259,39 +255,54 @@ public class ScalarInputEditor extends BEASTObjectInputEditor {
             	}
             	
             	String id = parameter2.getID();
-            	
 
-            	if (id.startsWith("RealParameter")) {
-                	ScalarDistribution<?,?> parent = null; 
+            	// generalises the legacy "RealParameter" prefix check: any parameter that
+            	// hasn't already been given a "parameter.<context>" id (spec params default
+            	// to e.g. "RealScalarParam.N", not "RealParameter.N") needs one, so that
+            	// $(n) substitution below and BeautiDoc's general "parameter.*" sync scan
+            	// (see BeautiDoc.applyBeautiRules) can find it
+            	if (id == null || !id.startsWith("parameter.")) {
+                	ScalarDistribution<?,?> parent = null;
     	            for (Object beastObject2 : parameter2.getOutputs()) {
-    	                if (beastObject2 instanceof ScalarDistribution<?,?>) {
-                    		parent = (ScalarDistribution<?,?>) beastObject2; 
+    	                if (beastObject2 instanceof ScalarDistribution<?,?> sd && sd.paramInput.get() != parameter2) {
+                    		parent = sd;
     	                    break;
     	                }
     	            }
-    	            Distribution grandparent = null; 
-    	            for (Object beastObject2 : parent.getOutputs()) {
-    	                if (beastObject2 instanceof Distribution) {
-                    		grandparent = (Distribution) beastObject2; 
-    	                    break;
-    	                }
-    	            }
-            		id = "parameter.hyper" + parent.getClass().getSimpleName() + "-" + 
-            				m_input.getName() + "-" + grandparent.getID();
+            		if (parent == null) {
+            			Log.err.println("Could not find the distribution owning " + parameter2.getID() + "; not adding a hyperprior");
+            			m_isEstimatedBox.setSelected(false);
+            			parameter2.isEstimatedInput.setValue(false, parameter2);
+            			return;
+            		}
+            		// parent's own id is already partition-specific in the spec framework
+            		// (e.g. "ClockPrior.c:1stpos", connected directly into 'prior') -- there
+            		// is no separate wrapping Prior object to look up any more
+            		id = "parameter.hyper" + parent.getClass().getSimpleName() + "-" +
+            				m_input.getName() + "-" + parent.getID();
             		doc.pluginmap.remove(parameter2.getID());
             		parameter2.setID(id);
             		doc.addPlugin(parameter2);
             	}
-            	
-            	
+
             	PartitionContext context = new PartitionContext(id.substring("parameter.".length()));
             	Log.warning.println(context + " " + id);
-            	doc.beautiConfig.hyperPriorTemplate.createSubNet(context, true);
+
+            	// the default hyperprior distribution must be domain-compatible with the
+            	// parameter it is applied to, or it shows up as a mismatched entry outside
+            	// the compatible-domain dropdown list in the Priors panel (see
+            	// ScalarDistributionInputEditor.isCompatible)
+            	boolean isPositive = parameter2 instanceof RealScalarParam<?> realParam &&
+            			(realParam.getDomain() instanceof PositiveReal || realParam.getDomain() instanceof NonNegativeReal);
+            	BeautiSubTemplate hyperTemplate = isPositive ?
+            			doc.beautiConfig.hyperPriorSpecPositiveTemplate :
+            			doc.beautiConfig.hyperPriorSpecTemplate;
+            	hyperTemplate.createSubNet(context, true);
             }
         	hardSync();
             refreshPanel();
         } catch (Exception ex) {
-            Log.err.println("ParameterInputEditor " + ex.getMessage());
+            Log.err.println("ScalarInputEditor " + ex.getMessage());
         }
     }
     

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
@@ -181,8 +181,8 @@
 ]]>
         </subtemplate>
 
-        <!-- OneOnX (improper 1/x prior) removed in beast3; use LogUniform instead, -->
-        <!-- a proper, scale-invariant replacement bounded on [lower, upper]. -->
+        <!-- OneOnX (improper 1/x prior) is removed from the BEAUti distribution list; -->
+        <!-- use LogUniform as a replacement to a PositiveReal-domain param bounded on [lower, upper]. -->
         <subtemplate id='LogUniform' class='beast.base.spec.inference.distribution.LogUniform' mainid='[top]'
                      suppressInputs='beast.base.spec.inference.distribution.LogUniform.param'
                      hmc='

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
@@ -210,11 +210,13 @@
 
         <!-- Dirichlet -->
         <subtemplate id='Dirichlet' class='beast.base.spec.inference.distribution.Dirichlet' mainid='[top]'
+        	suppressInputs='beast.base.spec.inference.distribution.Dirichlet.param'
             hmc='
             Dirichlet/alpha/=ParametricDistributions/Dirichlet/mean/,
             Dirichlet/offset/=ParametricDistributions/Dirichlet/offset/'>
             <![CDATA[
 			<distr spec="beast.base.spec.inference.distribution.Dirichlet">
+                <param spec="beast.base.spec.inference.parameter.SimplexParam" dimension="1" value="1.0" estimate="false"/>
                 <alpha spec="beast.base.spec.inference.parameter.RealVectorParam" domain="PositiveReal" estimate="false">1.0</alpha>
             </distr>
 ]]>

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
@@ -33,12 +33,12 @@
 ]]>
         </subtemplate>
 
-        <!-- OneOnX -->
-        <subtemplate id='1/X' class='beast.base.inference.distribution.OneOnX' mainid='[top]'>
-            <![CDATA[        
-            <distr spec="beast.base.inference.distribution.OneOnX"/>
-]]>
-        </subtemplate>
+        <!-- OneOnX removed in beast3 -->
+<!--        <subtemplate id='1/X' class='beast.base.inference.distribution.OneOnX' mainid='[top]'>-->
+<!--            <![CDATA[        -->
+<!--            <distr spec="beast.base.inference.distribution.OneOnX"/>-->
+<!--]]>-->
+<!--        </subtemplate>-->
 
         <!-- lognormal -->
         <subtemplate id='LogNormal' class='beast.base.spec.inference.distribution.LogNormal' mainid='[top]'

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
@@ -33,13 +33,6 @@
 ]]>
         </subtemplate>
 
-        <!-- OneOnX removed in beast3 -->
-<!--        <subtemplate id='1/X' class='beast.base.inference.distribution.OneOnX' mainid='[top]'>-->
-<!--            <![CDATA[        -->
-<!--            <distr spec="beast.base.inference.distribution.OneOnX"/>-->
-<!--]]>-->
-<!--        </subtemplate>-->
-
         <!-- lognormal -->
         <subtemplate id='LogNormal' class='beast.base.spec.inference.distribution.LogNormal' mainid='[top]'
         	suppressInputs='beast.base.spec.inference.distribution.LogNormal.param'
@@ -184,6 +177,21 @@
         <distr spec="beast.base.spec.inference.distribution.InverseGamma">
                 <alpha spec="beast.base.spec.inference.parameter.RealScalarParam" domain="PositiveReal" value="2.0" estimate="false"/>
                 <beta spec="beast.base.spec.inference.parameter.RealScalarParam" domain="PositiveReal" value="2.0" estimate="false"/>
+        </distr>
+]]>
+        </subtemplate>
+
+        <!-- OneOnX (improper 1/x prior) removed in beast3; use LogUniform instead, -->
+        <!-- a proper, scale-invariant replacement bounded on [lower, upper]. -->
+        <subtemplate id='LogUniform' class='beast.base.spec.inference.distribution.LogUniform' mainid='[top]'
+                     suppressInputs='beast.base.spec.inference.distribution.LogUniform.param'
+                     hmc='
+			LogUniform/lower/=ParametricDistributions/LogUniform/lower/,
+			LogUniform/upper/=ParametricDistributions/LogUniform/upper/'>
+            <![CDATA[
+        <distr spec="beast.base.spec.inference.distribution.LogUniform">
+                <lower spec="beast.base.spec.inference.parameter.RealScalarParam" domain="PositiveReal" value="1.0E-8" estimate="false"/>
+                <upper spec="beast.base.spec.inference.parameter.RealScalarParam" domain="PositiveReal" value="1.0E8" estimate="false"/>
         </distr>
 ]]>
         </subtemplate>

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/Standard.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/Standard.xml
@@ -126,6 +126,18 @@
             beast.base.spec.inference.parameter.IntScalarParam.domain,
             beast.base.spec.inference.parameter.RealVectorParam.domain,
             beast.base.spec.inference.parameter.IntVectorParam.domain,
+            beast.base.spec.inference.parameter.RealVectorParam.shape,
+            beast.base.spec.inference.parameter.RealVectorParam.keys,
+            beast.base.spec.inference.parameter.IntVectorParam.shape,
+            beast.base.spec.inference.parameter.IntVectorParam.keys,
+            beast.base.spec.inference.parameter.BoolVectorParam.shape,
+            beast.base.spec.inference.parameter.BoolVectorParam.keys,
+            beast.base.spec.inference.parameter.SimplexParam.domain,
+            beast.base.spec.inference.parameter.SimplexParam.shape,
+            beast.base.spec.inference.parameter.SimplexParam.keys,
+            beast.base.spec.inference.parameter.IntSimplexParam.domain,
+            beast.base.spec.inference.parameter.IntSimplexParam.shape,
+            beast.base.spec.inference.parameter.IntSimplexParam.keys,
             beast.base.spec.inference.distribution.IID.param,
             beast.base.spec.inference.distribution.MarkovChainDistribution.param
             '

--- a/beast-fx/src/test/java/test/beastfx/app/beauti/HyperPriorTest.java
+++ b/beast-fx/src/test/java/test/beastfx/app/beauti/HyperPriorTest.java
@@ -1,0 +1,158 @@
+package test.beastfx.app.beauti;
+
+
+import beast.base.inference.CompoundDistribution;
+import beast.base.inference.Distribution;
+import beast.base.spec.inference.distribution.Gamma;
+import beast.base.spec.inference.distribution.LogNormal;
+import beast.base.spec.inference.distribution.Normal;
+import beastfx.app.beauti.BeautiTabPane;
+import javafx.application.Platform;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.service.query.NodeQuery;
+import org.testfx.util.WaitForAsyncUtils;
+
+import java.io.File;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * Checking "estimate" on a distribution's own parameter (e.g. LogNormal's M or S) is meant to
+ * add a "hyper prior" for that parameter to the Priors panel (after confirming the "Hyper prior"
+ * warning dialog). This used to silently do nothing in the spec framework, because the parameter's
+ * auto-generated id ("RealScalarParam.N") never matched the legacy "RealParameter" prefix check
+ * that triggers renaming + hyper prior creation. It was also possible for the newly created
+ * hyper prior's distribution to be domain-incompatible with the target parameter (e.g. a Normal,
+ * which is Real-domain, assigned to S, which is PositiveReal-domain).
+ */
+@ExtendWith(ApplicationExtension.class)
+public class HyperPriorTest extends BeautiBase {
+
+	@Start
+	public void start(Stage stage) {
+		System.setProperty("beast.is.junit.testing", "true");
+		try {
+			BeautiTabPane tabPane = BeautiTabPane.main2(new String[] {}, stage);
+			this.doc = tabPane.doc;
+			stage.show();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Test
+	public void addHyperPriorForRealDomainParameter(FxRobot robot) throws Exception {
+		switchBirthRatePriorToLogNormal(robot);
+
+		int priorCountBefore = priors().size();
+
+		// M (mean) is Real-domain: unbounded, so a Normal hyper prior is domain-compatible
+		fireCheckBox(robot, "M.isEstimated");
+		WaitForAsyncUtils.waitForFxEvents();
+		robot.clickOn("Yes");
+		WaitForAsyncUtils.waitForFxEvents();
+
+		List<Distribution> priors = priors();
+		assertThat(priors.size()).as("hyper prior for M should have been added to the Priors panel")
+				.isEqualTo(priorCountBefore + 1);
+		assertThat(lastPrior(priors)).as("hyper prior for a Real-domain parameter should be a Normal")
+				.isInstanceOf(Normal.class);
+
+		makeSureXMLParses();
+	}
+
+	@Test
+	public void addHyperPriorForPositiveRealDomainParameter(FxRobot robot) throws Exception {
+		switchBirthRatePriorToLogNormal(robot);
+
+		int priorCountBefore = priors().size();
+
+		// S (stdev) is PositiveReal-domain: a Normal hyper prior (Real-domain) would be
+		// domain-incompatible and show up as a mismatched entry in its distribution dropdown
+		fireCheckBox(robot, "S.isEstimated");
+		WaitForAsyncUtils.waitForFxEvents();
+		robot.clickOn("Yes");
+		WaitForAsyncUtils.waitForFxEvents();
+
+		List<Distribution> priors = priors();
+		assertThat(priors.size()).as("hyper prior for S should have been added to the Priors panel")
+				.isEqualTo(priorCountBefore + 1);
+		assertThat(lastPrior(priors)).as("hyper prior for a PositiveReal-domain parameter should be domain-compatible (Gamma), not Normal")
+				.isInstanceOf(Gamma.class);
+
+		makeSureXMLParses();
+	}
+
+	/** switch the birth rate's prior from the default Gamma to LogNormal, which has its own
+	 * M (Real-domain) and S (PositiveReal-domain) parameters to toggle "estimate" on */
+	private void switchBirthRatePriorToLogNormal(FxRobot robot) throws Exception {
+		importAlignment(NEXUS_DIR, new File("anolis.nex"));
+		WaitForAsyncUtils.waitForFxEvents();
+
+		selectTab(robot, "Priors");
+		WaitForAsyncUtils.waitForFxEvents();
+
+		selectDistribution(robot, "birthRate.t:anolis.distr", "Log Normal");
+		WaitForAsyncUtils.waitForFxEvents();
+
+		Distribution birthRatePrior = null;
+		for (Distribution d : priors()) {
+			if (d instanceof LogNormal) {
+				birthRatePrior = d;
+			}
+		}
+		assertThat(birthRatePrior).as("birth rate prior should now be a LogNormal").isNotNull();
+	}
+
+	/** fires the "estimate" checkbox with the given fx:id directly via the API, rather than a
+	 * screen-coordinate click, and without robot.interact()'s wait-for-completion: toggling
+	 * this checkbox pops a nested modal "Hyper prior" confirmation dialog, which needs a
+	 * *separate* robot action (see the caller) to dismiss -- interact() would deadlock waiting
+	 * for a Runnable that can't finish until that later action runs. */
+	private void fireCheckBox(FxRobot robot, String id) {
+		NodeQuery q = robot.lookup(target -> id.equals(target.getId()) && target.isVisible());
+		CheckBox cb = (CheckBox) q.query();
+		Platform.runLater(() -> {
+			if (!cb.isSelected()) {
+				cb.fire();
+			}
+		});
+	}
+
+	/** select an item (matched by its combo-box display text, e.g. "Log Normal") from a
+	 * distribution ComboBox, driving the ComboBox API directly rather than the dropdown UI
+	 * (avoids the ComboBox's popup window sticking open, which then swallows later clicks). */
+	@SuppressWarnings("unchecked")
+	private void selectDistribution(FxRobot robot, String comboBoxId, String displayText) {
+		NodeQuery q = robot.lookup(target -> comboBoxId.equals(target.getId()) && target.isVisible());
+		ComboBox<Object> comboBox = (ComboBox<Object>) q.query();
+		robot.interact(() -> {
+			for (Object item : comboBox.getItems()) {
+				if (item.toString().equals(displayText)) {
+					comboBox.getSelectionModel().select(item);
+					return;
+				}
+			}
+			throw new AssertionError("No item \"" + displayText + "\" in ComboBox #" + comboBoxId);
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<Distribution> priors() {
+		CompoundDistribution prior = (CompoundDistribution) doc.pluginmap.get("prior");
+		return prior.pDistributions.get();
+	}
+
+	private Distribution lastPrior(List<Distribution> priors) {
+		return priors.get(priors.size() - 1);
+	}
+}


### PR DESCRIPTION
Fix #157, #159 and #160

Restores the ability to add a hyper prior on a distribution's own parameter (e.g. LogNormal's M/S) from the Priors panel, for the new beast.base.spec distribution/parameter classes. Three independent bugs were compounding:

1. The checkbox-visibility check (ScalarInputEditor) was mis-ported from the legacy editor.
2. toggleEstimate()'s id/context logic assumed the legacy Prior-wrapper object model.
3. The default hyper-prior template used deprecated classes incompatible with the new parameter types, and (once fixed) needed to pick a domain-appropriate distribution.

Changes

- beastfx/app/inputeditor/spec/ScalarInputEditor.java
  - addComboBox(): fixed the mis-ported check from beastObject2 instanceof RealScalarParam to beastObject2 instanceof ScalarDistribution<?,?> sd && sd.paramInput.get() != parameter — correctly identifies "this parameter is a distribution's own hyperparameter" (mean/sigma/alpha/theta/...) as opposed to "this parameter is the distribution's target," which is what actually makes the estimate checkbox appear outside Expert Mode.
  - toggleEstimate():
    - Generalized id.startsWith("RealParameter") to !id.startsWith("parameter."), so spec parameters (whose auto-ids look like "RealScalarParam.N") get renamed and picked up by BeautiDoc's general "parameter.*" sync scan.
    - Replaced the legacy "grandparent" lookup with using the owning distribution's own id directly (parent.getID()) — the flattened spec model no longer has a separate wrapping Prior object, so that id is already partition-specific.
    - Selects between two new hyper-prior templates based on the target parameter's domain.
- beastfx/app/inputeditor/BeautiConfig.java
  - Added two new hyper-prior templates, registered as hyperPriorSpecTemplate and hyperPriorSpecPositiveTemplate, parsed with their own XMLParser instance each (note: reusing one XMLParser across multiple parseBareFragment() calls corrupts internal DOM state — hit this directly while developing the fix).
    - HYPER_PRIOR_SPEC_XML (Real-domain, e.g. LogNormal's M): Normal + RealRandomWalkOperator (additive; safe for a value that may be zero or negative).
    - HYPER_PRIOR_SPEC_POSITIVE_XML (PositiveReal/NonNegativeReal-domain, e.g. LogNormal's S, Gamma's alpha/theta): Gamma(alpha=0.001, theta=1000) + ScaleOperator, matching the existing weak-Gamma-prior convention already used for MutationRatePrior/ClockPrior/YuleBirthRatePrior.
  - Left hyperPriorTemplate/HYPER_PRIOR_XML (legacy Prior+OneOnX+ScaleOperator) untouched — it's still exercised by ParameterInputEditor when editing an old, pre-existing analysis file that has genuine legacy RealParameter objects, even though LegacyStandard.xml is no longer used to start new analyses.
- beastfx/app/inputeditor/BeautiDoc.java
  - Registered both new templates in the general "parameter.*" id sync scan (applyBeautiRules), alongside the existing legacy one, so hyper-prior connects stay correct on future doc-wide syncs regardless of which template originally created them.
- beast-fx/src/test/java/test/beastfx/app/beauti/HyperPriorTest.java (new)
  - addHyperPriorForRealDomainParameter: switches the birth rate's prior to LogNormal, checks "estimate" on M, confirms the dialog, asserts a Normal hyper prior is added to the Priors panel.
  - addHyperPriorForPositiveRealDomainParameter: same for S, asserts a domain-compatible Gamma (not Normal) is added.

Testing

- `mvn -pl beast-fx -am test -Pslow-tests -Dtest='test.beastfx.app.**' -Dsurefire.failIfNoSpecifiedTests=false` → Tests run: 48, Failures: 0, Errors: 0, Skipped: 6
- Verified both new tests fail against the pre-fix code (checkbox not found / wrong distribution class), confirming they're real regression coverage, not vacuous.

Notes for reviewers

- RealScalarParam's domain (Real vs PositiveReal/NonNegativeReal) determines which hyper-prior template is used; other domains (e.g. UnitInterval) fall back to the Real-domain template as a safe default.
- Hyper priors for IntScalarParam/BoolScalarParam distribution parameters are not supported by this change (rare in practice — e.g. IntUniform's bounds); toggleEstimate() shows a message and reverts the checkbox for those rather than silently breaking.