### PR TITLE
Fix several simple bugs in Prior panel

### DIFF
--- a/beast-fx/src/main/java/beastfx/app/inputeditor/IIDInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/IIDInputEditor.java
@@ -1,36 +1,16 @@
 package beastfx.app.inputeditor;
 
 
-
-
-
-
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import beast.base.core.BEASTInterface;
 import beast.base.core.Input;
 import beast.base.inference.Distribution;
 import beast.base.parser.PartitionContext;
-import beast.base.spec.domain.Int;
-import beast.base.spec.domain.NonNegativeInt;
-import beast.base.spec.domain.NonNegativeReal;
-import beast.base.spec.domain.PositiveInt;
-import beast.base.spec.domain.PositiveReal;
-import beast.base.spec.domain.Real;
+import beast.base.spec.domain.*;
 import beast.base.spec.inference.distribution.IID;
 import beast.base.spec.inference.distribution.ScalarDistribution;
 import beast.base.spec.inference.distribution.TensorDistribution;
-import beast.base.spec.inference.parameter.BoolScalarParam;
-import beast.base.spec.inference.parameter.IntScalarParam;
-import beast.base.spec.inference.parameter.IntVectorParam;
-import beast.base.spec.inference.parameter.RealScalarParam;
-import beast.base.spec.inference.parameter.RealVectorParam;
-import beast.base.spec.type.IntScalar;
+import beast.base.spec.inference.parameter.*;
 import beast.base.spec.type.IntVector;
-import beast.base.spec.type.RealScalar;
 import beast.base.spec.type.RealVector;
 import beast.base.spec.type.Scalar;
 import beastfx.app.util.FXUtils;
@@ -42,6 +22,10 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class IIDInputEditor extends ScalarDistributionInputEditor {
 
@@ -118,7 +102,7 @@ public class IIDInputEditor extends ScalarDistributionInputEditor {
                 List<?> list = (List<?>) m_input.get();
                 TensorDistribution<?,?> prior1 = (TensorDistribution<?,?>) list.get(itemNr);
                 BEASTInterface p1 = (BEASTInterface) prior1.paramInput.get();
-                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, RealScalar.class, doc);
+                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, p1.getClass(), doc);
                 if (dlg.showDialog()) {
                     dlg.accept(p1, doc);
                     ((BEASTInterface)p1).initAndValidate();
@@ -139,7 +123,7 @@ public class IIDInputEditor extends ScalarDistributionInputEditor {
                 List<?> list = (List<?>) m_input.get();
                 TensorDistribution<?,?> prior1 = (TensorDistribution<?,?>) list.get(itemNr);
                 BEASTInterface p1 = (BEASTInterface) prior1.paramInput.get();
-                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, IntScalar.class, doc);
+                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, p1.getClass(), doc);
                 if (dlg.showDialog()) {
                     dlg.accept(p1, doc);
                     p1.initAndValidate();

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/ScalarDistributionInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/ScalarDistributionInputEditor.java
@@ -165,7 +165,7 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
 	                	return;
 	                }
 	                BEASTInterface p1 = (BEASTInterface) prior1.paramInput.get();
-	                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, RealScalar.class, doc);
+	                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, p1.getClass(), doc);
 	                if (dlg.showDialog()) {
 	                    dlg.accept(p1, doc);
 	                    ((BEASTInterface)p1).initAndValidate();
@@ -188,7 +188,7 @@ public class ScalarDistributionInputEditor extends BEASTObjectInputEditor implem
 	                	return;
 	                }
 	                BEASTInterface p1 = (BEASTInterface) prior1.paramInput.get();
-	                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, IntScalar.class, doc);
+	                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, p1.getClass(), doc);
 	                if (dlg.showDialog()) {
 	                    dlg.accept(p1, doc);
 	                    p1.initAndValidate();

--- a/beast-fx/src/main/java/beastfx/app/inputeditor/TensorDistributionInputEditor.java
+++ b/beast-fx/src/main/java/beastfx/app/inputeditor/TensorDistributionInputEditor.java
@@ -9,7 +9,9 @@ import beast.base.spec.domain.*;
 import beast.base.spec.inference.distribution.ScalarDistribution;
 import beast.base.spec.inference.distribution.TensorDistribution;
 import beast.base.spec.inference.parameter.*;
-import beast.base.spec.type.*;
+import beast.base.spec.type.IntVector;
+import beast.base.spec.type.RealVector;
+import beast.base.spec.type.Scalar;
 import beastfx.app.util.FXUtils;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
@@ -98,7 +100,7 @@ public class TensorDistributionInputEditor extends BEASTObjectInputEditor implem
                 List<?> list = (List<?>) m_input.get();
                 TensorDistribution<?,?> prior1 = (TensorDistribution<?,?>) list.get(itemNr);
                 BEASTInterface p1 = (BEASTInterface) prior1.paramInput.get();
-                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, RealScalar.class, doc);
+                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, p1.getClass(), doc);
                 if (dlg.showDialog()) {
                     dlg.accept(p1, doc);
                     ((BEASTInterface)p1).initAndValidate();
@@ -119,7 +121,7 @@ public class TensorDistributionInputEditor extends BEASTObjectInputEditor implem
                 List<?> list = (List<?>) m_input.get();
                 TensorDistribution<?,?> prior1 = (TensorDistribution<?,?>) list.get(itemNr);
                 BEASTInterface p1 = (BEASTInterface) prior1.paramInput.get();
-                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, IntScalar.class, doc);
+                BEASTObjectDialog dlg = new BEASTObjectDialog(p1, p1.getClass(), doc);
                 if (dlg.showDialog()) {
                     dlg.accept(p1, doc);
                     p1.initAndValidate();

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
@@ -181,8 +181,8 @@
 ]]>
         </subtemplate>
 
-        <!-- OneOnX (improper 1/x prior) removed in beast3; use LogUniform instead, -->
-        <!-- a proper, scale-invariant replacement bounded on [lower, upper]. -->
+        <!-- OneOnX (improper 1/x prior) is removed from the BEAUti distribution list; -->
+        <!-- use LogUniform as a replacement to a PositiveReal-domain param bounded on [lower, upper]. -->
         <subtemplate id='LogUniform' class='beast.base.spec.inference.distribution.LogUniform' mainid='[top]'
                      suppressInputs='beast.base.spec.inference.distribution.LogUniform.param'
                      hmc='

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
@@ -33,13 +33,6 @@
 ]]>
         </subtemplate>
 
-        <!-- OneOnX -->
-        <subtemplate id='1/X' class='beast.base.inference.distribution.OneOnX' mainid='[top]'>
-            <![CDATA[        
-            <distr spec="beast.base.inference.distribution.OneOnX"/>
-]]>
-        </subtemplate>
-
         <!-- lognormal -->
         <subtemplate id='LogNormal' class='beast.base.spec.inference.distribution.LogNormal' mainid='[top]'
         	suppressInputs='beast.base.spec.inference.distribution.LogNormal.param'
@@ -184,6 +177,21 @@
         <distr spec="beast.base.spec.inference.distribution.InverseGamma">
                 <alpha spec="beast.base.spec.inference.parameter.RealScalarParam" domain="PositiveReal" value="2.0" estimate="false"/>
                 <beta spec="beast.base.spec.inference.parameter.RealScalarParam" domain="PositiveReal" value="2.0" estimate="false"/>
+        </distr>
+]]>
+        </subtemplate>
+
+        <!-- OneOnX (improper 1/x prior) removed in beast3; use LogUniform instead, -->
+        <!-- a proper, scale-invariant replacement bounded on [lower, upper]. -->
+        <subtemplate id='LogUniform' class='beast.base.spec.inference.distribution.LogUniform' mainid='[top]'
+                     suppressInputs='beast.base.spec.inference.distribution.LogUniform.param'
+                     hmc='
+			LogUniform/lower/=ParametricDistributions/LogUniform/lower/,
+			LogUniform/upper/=ParametricDistributions/LogUniform/upper/'>
+            <![CDATA[
+        <distr spec="beast.base.spec.inference.distribution.LogUniform">
+                <lower spec="beast.base.spec.inference.parameter.RealScalarParam" domain="PositiveReal" value="1.0E-8" estimate="false"/>
+                <upper spec="beast.base.spec.inference.parameter.RealScalarParam" domain="PositiveReal" value="1.0E8" estimate="false"/>
         </distr>
 ]]>
         </subtemplate>

--- a/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
+++ b/beast-fx/src/main/resources/beast.fx/fxtemplates/ParametricDistributions.xml
@@ -210,11 +210,13 @@
 
         <!-- Dirichlet -->
         <subtemplate id='Dirichlet' class='beast.base.spec.inference.distribution.Dirichlet' mainid='[top]'
+        	suppressInputs='beast.base.spec.inference.distribution.Dirichlet.param'
             hmc='
             Dirichlet/alpha/=ParametricDistributions/Dirichlet/mean/,
             Dirichlet/offset/=ParametricDistributions/Dirichlet/offset/'>
             <![CDATA[
 			<distr spec="beast.base.spec.inference.distribution.Dirichlet">
+                <param spec="beast.base.spec.inference.parameter.SimplexParam" dimension="1" value="1.0" estimate="false"/>
                 <alpha spec="beast.base.spec.inference.parameter.RealVectorParam" domain="PositiveReal" estimate="false">1.0</alpha>
             </distr>
 ]]>


### PR DESCRIPTION
#159 — OneOnX prior removed in beast3, BEAUti had no replacement

Fix (beba5a4, c6093be):
- Removed the leftover OneOnX template entry.
- Added a LogUniform template instead — a proper, scale-invariant prior bounded on [1e-8, 1e8] for PositiveReal parameters, replacing the improper 1/x prior.
- Tidied the explanatory comment above it.

#160 — Prior panel showing wrong info for parameters

Two separate bugs under this issue:

Bug 1 — Dirichlet prior parameter not shown (d7766f6):
The Dirichlet template was missing its param (simplex) input and suppressInputs setting, so BEAUti displayed it incorrectly in the Priors panel.
Fix: Added the missing SimplexParam and suppressInputs to the template.

Bug 2 — Wrong "type" label in the initial-value dialog (ebb69b9):
When you click a parameter's value/range button in the Priors panel, BEAUti opens a dialog whose title label is built from a Class argument. That argument was hardcoded to a generic interface (RealScalar.class, IntScalar.class) instead of the parameter's real class — so every dialog showed the same generic label (e.g. "RealScalar:") regardless of what parameter you were actually editing, and in two cases (IIDInputEditor, TensorDistributionInputEditor) it even used the scalar interface for vector parameters.
Fix: Pass p1.getClass() (the parameter's actual class) instead, in ScalarDistributionInputEditor, IIDInputEditor, and TensorDistributionInputEditor — 5 call sites total. Removed now-unused imports.